### PR TITLE
Use alternate Xdebug installation method on PHP 5.6

### DIFF
--- a/installer/stretch/extensions/xdebug.sh
+++ b/installer/stretch/extensions/xdebug.sh
@@ -4,7 +4,22 @@ function install_xdebug()
 {
     case "$VERSION" in
             "5.6")
-                printf "\n" | pecl install xdebug-2.5.5
+                BEFORE_PWD=$(pwd) \
+                    && mkdir -p /opt/xdebug \
+                    && cd /opt/xdebug \
+                    && curl https://xdebug.org/files/xdebug-2.5.5.tgz -o xdebug-2.5.5.tgz \
+                    && echo "72108bf2bc514ee7198e10466a0fedcac3df9bbc5bd26ce2ec2dafab990bf1a4" "xdebug-2.5.5.tgz" | sha256sum --check \
+                    && tar -xzvf xdebug-2.5.5.tgz \
+                    && cd xdebug-2.5.5 \
+                    && phpize \
+                    && ./configure --enable-xdebug \
+                    && make clean \
+                    && sed -i 's/-O2/-O0/g' Makefile \
+                    && make \
+                    && make test \
+                    && make install \
+                    && cd "${BEFORE_PWD}" \
+                    && rm -r /opt/xdebug
                 ;;
             *)
                 printf "\n" | pecl install xdebug


### PR DESCRIPTION
I've been experiencing an issue on various projects when debugging code that involves static properties. Stepping over lines that utilise a static property often causes an error, `Fatal error: Access to undeclared static property`.

I've added the workaround detailed in `https://github.com/docker-library/php/issues/133` to this PR to compile Xdebug from source with different args, which stops the error occurring.

I've tested this locally by building the image and using Xdebug with some sample code and was able to step through it all without any errors.