### PR TITLE
Downgrade protobuf package version for PHP 5.6

### DIFF
--- a/installer/stretch/extensions/protobuf.sh
+++ b/installer/stretch/extensions/protobuf.sh
@@ -2,6 +2,13 @@
 
 function install_protobuf()
 {
-    pecl install protobuf
+    case "$VERSION" in
+            "5.6")
+                printf "\n" | pecl install protobuf-3.12.4
+                ;;
+            *)
+                printf "\n" | pecl install protobuf
+    esac
+
     docker-php-ext-enable protobuf
 }


### PR DESCRIPTION
Release 3.13.0 supports PHP 7.0+ only, so the build is failing