### PR TITLE
Add Tideways Installer

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -5,6 +5,7 @@ FROM php:${VERSION}-fpm-${BASEOS}
 # Base Packages
 # ---
 ARG BASEOS=stretch
+ENV IMAGE_TYPE=base
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && if [ "$VERSION" != "5.6" ] && [ "$VERSION" != "7.0" ] && [ "$VERSION" != "7.1" ] && [ "$BASEOS" = "stretch" ]; then echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list; fi \

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -5,6 +5,7 @@ FROM my127/php:${VERSION}-fpm-${BASEOS}
 STOPSIGNAL SIGTERM
 
 ARG BASEOS=stretch
+ENV IMAGE_TYPE=console
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && apt-get update -qq \

--- a/installer/stretch/extensions/tideways.sh
+++ b/installer/stretch/extensions/tideways.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+function install_tideways()
+{
+    _tideways_deps_build
+    _tideways_deps_runtime
+}
+
+function _tideways_deps_runtime()
+{
+    local CLI_PACKAGE=''
+    if [[ "$IMAGE_TYPE" == "console" ]]; then
+        CLI_PACKAGE='tideways-cli'
+    fi
+
+    install \
+      tideways-php \
+      "$CLI_PACKAGE"
+}
+
+function _tideways_deps_build()
+{
+    install \
+      apt-transport-https \
+      gnupg2
+
+    echo 'deb https://packages.tideways.com/apt-packages debian main' > /etc/apt/sources.list.d/tideways.list
+    curl -L -sS 'https://packages.tideways.com/key.gpg' | apt-key add -
+}

--- a/installer/stretch/extensions/tideways.sh
+++ b/installer/stretch/extensions/tideways.sh
@@ -26,4 +26,5 @@ function _tideways_deps_build()
 
     echo 'deb https://packages.tideways.com/apt-packages debian main' > /etc/apt/sources.list.d/tideways.list
     curl -L -sS 'https://packages.tideways.com/key.gpg' | apt-key add -
+    apt-get update -qq
 }

--- a/installer/stretch/extensions/tideways.sh
+++ b/installer/stretch/extensions/tideways.sh
@@ -6,6 +6,11 @@ function install_tideways()
     _tideways_deps_runtime
 }
 
+function compile_tideways()
+{
+    :
+}
+
 function _tideways_deps_runtime()
 {
     local CLI_PACKAGE=''


### PR DESCRIPTION
Add extension and CLI for https://tideways.com/ when requested via /root/installer/enable.sh tideways.