### PR TITLE
Add Blackfire CLI

### DIFF
--- a/installer/stretch/extensions/blackfire.sh
+++ b/installer/stretch/extensions/blackfire.sh
@@ -16,7 +16,6 @@ function install_blackfire_probe()
     mkdir -p /tmp/blackfire
     tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire
     mv /tmp/blackfire/blackfire-*.so "$(php -r "echo ini_get('extension_dir');")/blackfire.so"
-    printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > "$PHP_INI_DIR/conf.d/blackfire.ini"
     rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 }
 

--- a/installer/stretch/extensions/blackfire.sh
+++ b/installer/stretch/extensions/blackfire.sh
@@ -2,11 +2,29 @@
 
 function install_blackfire()
 {
-    version="$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")" \
-      && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s "https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version" \
-      && mkdir -p /tmp/blackfire \
-      && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
-      && mv /tmp/blackfire/blackfire-*.so "$(php -r "echo ini_get('extension_dir');")/blackfire.so" \
-      && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > "$PHP_INI_DIR/conf.d/blackfire.ini" \
-      && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+    install_blackfire_probe
+    if [[ "$IMAGE_TYPE" == "console" ]]; then
+        install_blackfire_cli
+    fi
+}
+
+function install_blackfire_probe()
+{
+    local version
+    version="$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")"
+    curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s "https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version"
+    mkdir -p /tmp/blackfire
+    tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire
+    mv /tmp/blackfire/blackfire-*.so "$(php -r "echo ini_get('extension_dir');")/blackfire.so"
+    printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > "$PHP_INI_DIR/conf.d/blackfire.ini"
+    rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+}
+
+function install_blackfire_cli()
+{
+    mkdir -p /tmp/blackfire-cli
+    curl -A "Docker" -o /tmp/blackfire-cli.tar.gz -L https://blackfire.io/api/v1/releases/client/linux_static/amd64
+    tar zxpf /tmp/blackfire-cli.tar.gz -C /tmp/blackfire-cli
+    mv /tmp/blackfire-cli/blackfire /usr/bin/blackfire
+    rm -rf /tmp/blackfire-cli /tmp/blackfire-cli.tar.gz
 }


### PR DESCRIPTION
Add CLI for https://blackfire.io/ when requested via /root/installer/enable.sh blackfire and in the console image via environment variable for IMAGE_TYPE added in #38.