### PR TITLE
Pre-compile extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ services:
 
 matrix:
   include:
-    - env: BUILD="php56|php70|php71"
-    - env: BUILD="php72|php73"
+    - env: BUILD="php56"
+    - env: BUILD="php70"
+    - env: BUILD="php71"
+    - env: BUILD="php72"
+    - env: BUILD="php73"
     - env: BUILD="php74"
 
 script:

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -31,6 +31,8 @@ RUN cd /root/installer; ./enable.sh \
   mcrypt \
   opcache \
   pdo_mysql \
+  pdo_pgsql \
+  pgsql \
   soap \
   xdebug \
   xsl \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -24,7 +24,8 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
 # ---
 COPY installer/stretch /root/installer
 COPY "installer/$BASEOS" /root/installer
-RUN cd /root/installer; ./enable.sh \
+RUN cd /root/installer; ./precompile.sh \
+ && ./enable.sh \
   bcmath \
   gd \
   intl \

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -55,16 +55,16 @@ USER root
 
 # Tool: composer
 # --------------
-RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/b5a70434f0f582468a7824418553defaf67d5299/web/installer \
+RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/fb07bd70d93cf733c1c94aef7fc68502f81aca2b/web/installer \
  && php -r " \
-    \$signature = 'c5b9b6d368201a9db6f74e2611495f369991b72d9c8cbd3ffbc63edff210eb73d46ffbfce88669ad33695ef77dc76976'; \
+    \$signature = '8a6138e2a05a8c28539c9f0fb361159823655d7ad2deecb371b04a83966c61223adc522b0189079e3e9e277cd72b8897'; \
     \$hash = hash('sha384', file_get_contents('/tmp/installer.php')); \
     if (!hash_equals(\$signature, \$hash)) { \
         unlink('/tmp/installer.php'); \
         echo 'Integrity check failed, installer is either corrupt or worse.' . PHP_EOL; \
         exit(1); \
     }" \
- && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=1.9.3
+ && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=1.10.10
 
 # Tool: composer > hirak/prestissimo
 # ----------------------------------

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -1,6 +1,8 @@
 ARG VERSION=7.3
 ARG BASEOS=stretch
 FROM my127/php:${VERSION}-fpm-${BASEOS}
+# upstream is SIGQUIT, cli should be SIGTERM
+STOPSIGNAL SIGTERM
 
 ARG BASEOS=stretch
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -8,6 +8,7 @@ ARG BASEOS=stretch
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && apt-get update -qq \
+ && for i in $(seq 1 8); do mkdir -p "/usr/share/man/man$i"; done \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
   # package dependencies \
    autoconf \
@@ -24,6 +25,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
    nasm \
    openssh-client \
    patch \
+   postgresql-client \
    pv \
    rsync \
    unzip \
@@ -31,7 +33,8 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
   # clean \
  && apt-get auto-remove -qq -y \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && for i in $(seq 1 8); do rm -rf "/usr/share/man/man$i"; done
 
 # User: build
 # -----------

--- a/installer/buster/extensions/event.sh
+++ b/installer/buster/extensions/event.sh
@@ -2,11 +2,11 @@
 
 function install_event()
 {
-    _event_deps_runtime
-
     if ! has_extension event; then
         compile_event
     fi
+
+    _event_deps_runtime
 
     docker-php-ext-enable event
 }
@@ -35,6 +35,9 @@ function _event_deps_runtime()
 
 function _event_deps_build()
 {
+    enable \
+      sockets
+
     install \
       libevent-dev \
       libssl-dev
@@ -45,4 +48,8 @@ function _event_clean()
     remove \
       libevent-dev \
       libssl-dev
+
+    if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-sockets.ini" ]; then
+        rm "/usr/local/etc/php/conf.d/docker-php-ext-sockets.ini"
+    fi
 }

--- a/installer/buster/extensions/event.sh
+++ b/installer/buster/extensions/event.sh
@@ -3,10 +3,19 @@
 function install_event()
 {
     _event_deps_runtime
+
+    if ! has_extension event; then
+        compile_event
+    fi
+
+    docker-php-ext-enable event
+}
+
+function compile_event()
+{
     _event_deps_build
 
     printf "\n" | pecl install event
-    docker-php-ext-enable event
 
     _event_clean
 }

--- a/installer/buster/extensions/event.sh
+++ b/installer/buster/extensions/event.sh
@@ -15,7 +15,9 @@ function compile_event()
 {
     _event_deps_build
 
-    printf "\n" | pecl install event
+    if ! printf "\n" | pecl install event; then
+        return 1
+    fi
 
     _event_clean
 }

--- a/installer/buster/extensions/gd.sh
+++ b/installer/buster/extensions/gd.sh
@@ -3,6 +3,13 @@
 function install_gd()
 {
     _gd_deps_runtime
+    if ! has_extension gd; then
+        compile_gd
+    fi
+}
+
+function compile_gd()
+{
     _gd_deps_build
 
     case "$VERSION" in

--- a/installer/buster/extensions/gd.sh
+++ b/installer/buster/extensions/gd.sh
@@ -6,6 +6,7 @@ function install_gd()
     if ! has_extension gd; then
         compile_gd
     fi
+    docker-php-ext-enable gd
 }
 
 function compile_gd()

--- a/installer/buster/extensions/intl.sh
+++ b/installer/buster/extensions/intl.sh
@@ -3,6 +3,14 @@
 function install_intl()
 {
     _intl_deps_runtime
+    if ! has_extension intl; then
+        compile_intl
+    fi
+    docker-php-ext-enable intl
+}
+
+function compile_intl()
+{
     _intl_deps_build
 
     docker-php-ext-install intl

--- a/installer/buster/extensions/rdkafka.sh
+++ b/installer/buster/extensions/rdkafka.sh
@@ -3,9 +3,11 @@
 function install_rdkafka()
 {
     _rdkafka_deps_runtime
+
     if ! has_extension rdkafka; then
         compile_rdkafka
     fi
+
     docker-php-ext-enable rdkafka
 }
 

--- a/installer/buster/extensions/rdkafka.sh
+++ b/installer/buster/extensions/rdkafka.sh
@@ -3,10 +3,17 @@
 function install_rdkafka()
 {
     _rdkafka_deps_runtime
+    if ! has_extension rdkafka; then
+        compile_rdkafka
+    fi
+    docker-php-ext-enable rdkafka
+}
+
+function compile_rdkafka()
+{
     _rdkafka_deps_build
 
     pecl install rdkafka
-    docker-php-ext-enable rdkafka
 
     _rdkafka_clean
 }

--- a/installer/buster/extensions/sodium.sh
+++ b/installer/buster/extensions/sodium.sh
@@ -3,6 +3,16 @@
 function install_sodium()
 {
     _sodium_deps_runtime
+
+    if ! has_extension sodium; then
+        compile_sodium
+    fi
+
+    docker-php-ext-enable sodium
+}
+
+function compile_sodium()
+{
     _sodium_deps_build
 
     case "$VERSION" in

--- a/installer/buster/extensions/sodium.sh
+++ b/installer/buster/extensions/sodium.sh
@@ -8,7 +8,9 @@ function install_sodium()
         compile_sodium
     fi
 
-    docker-php-ext-enable sodium
+    if has_extension sodium; then
+        docker-php-ext-enable sodium
+    fi
 }
 
 function compile_sodium()

--- a/installer/stretch/enable.sh
+++ b/installer/stretch/enable.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -x
+set -e -o pipefail -x
 
 export BUILD_DEPS=(autoconf g++ make)
 export BUILD_DEPS_CLEAN=()

--- a/installer/stretch/extensions/apcu.sh
+++ b/installer/stretch/extensions/apcu.sh
@@ -2,7 +2,14 @@
 
 function install_apcu()
 {
+    if ! has_extension acpu; then
+        compile_apcu
+    fi
+    docker-php-ext-enable apcu
+}
 
+function compile_apcu()
+{
     case "$VERSION" in
             "5.6")
                 printf "\n" | pecl install apcu-4.0.11
@@ -10,5 +17,4 @@ function install_apcu()
             *)
                 printf "\n" | pecl install apcu
     esac
-    docker-php-ext-enable apcu
 }

--- a/installer/stretch/extensions/apcu.sh
+++ b/installer/stretch/extensions/apcu.sh
@@ -2,7 +2,7 @@
 
 function install_apcu()
 {
-    if ! has_extension acpu; then
+    if ! has_extension apcu; then
         compile_apcu
     fi
     docker-php-ext-enable apcu

--- a/installer/stretch/extensions/blackfire.sh
+++ b/installer/stretch/extensions/blackfire.sh
@@ -10,7 +10,7 @@ function install_blackfire()
 
 function compile_blackfire()
 {
-    install_blackfire
+    :
 }
 
 function install_blackfire_probe()
@@ -21,6 +21,7 @@ function install_blackfire_probe()
     mkdir -p /tmp/blackfire
     tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire
     mv /tmp/blackfire/blackfire-*.so "$(php -r "echo ini_get('extension_dir');")/blackfire.so"
+    chown root:staff "$(php -r "echo ini_get('extension_dir');")/blackfire.so"
     rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 }
 

--- a/installer/stretch/extensions/blackfire.sh
+++ b/installer/stretch/extensions/blackfire.sh
@@ -8,6 +8,11 @@ function install_blackfire()
     fi
 }
 
+function compile_blackfire()
+{
+    install_blackfire
+}
+
 function install_blackfire_probe()
 {
     local version

--- a/installer/stretch/extensions/bz2.sh
+++ b/installer/stretch/extensions/bz2.sh
@@ -6,6 +6,7 @@ function install_bz2()
     if ! has_extension bz2; then
         compile_bz2
     fi
+    docker-php-ext-enable bz2
 }
 
 function compile_bz2()

--- a/installer/stretch/extensions/bz2.sh
+++ b/installer/stretch/extensions/bz2.sh
@@ -3,6 +3,13 @@
 function install_bz2()
 {
     _bz2_deps_runtime
+    if ! has_extension bz2; then
+        compile_bz2
+    fi
+}
+
+function compile_bz2()
+{
     _bz2_deps_build
 
     docker-php-ext-install bz2

--- a/installer/stretch/extensions/event.sh
+++ b/installer/stretch/extensions/event.sh
@@ -2,11 +2,11 @@
 
 function install_event()
 {
-    _event_deps_runtime
-
     if ! has_extension event; then
         compile_event
     fi
+
+    _event_deps_runtime
 
     docker-php-ext-enable event
 }
@@ -35,6 +35,9 @@ function _event_deps_runtime()
 
 function _event_deps_build()
 {
+    enable \
+      sockets
+
     install \
       libevent-dev \
       libssl-dev
@@ -45,4 +48,8 @@ function _event_clean()
     remove \
       libevent-dev \
       libssl-dev
+
+    if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-sockets.ini" ]; then
+        rm "/usr/local/etc/php/conf.d/docker-php-ext-sockets.ini"
+    fi
 }

--- a/installer/stretch/extensions/event.sh
+++ b/installer/stretch/extensions/event.sh
@@ -3,10 +3,19 @@
 function install_event()
 {
     _event_deps_runtime
+
+    if ! has_extension event; then
+        compile_event
+    fi
+
+    docker-php-ext-enable event
+}
+
+function compile_event()
+{
     _event_deps_build
 
     printf "\n" | pecl install event
-    docker-php-ext-enable event
 
     _event_clean
 }

--- a/installer/stretch/extensions/event.sh
+++ b/installer/stretch/extensions/event.sh
@@ -15,7 +15,9 @@ function compile_event()
 {
     _event_deps_build
 
-    printf "\n" | pecl install event
+    if ! printf "\n" | pecl install event; then
+        return 1
+    fi
 
     _event_clean
 }

--- a/installer/stretch/extensions/gd.sh
+++ b/installer/stretch/extensions/gd.sh
@@ -3,6 +3,13 @@
 function install_gd()
 {
     _gd_deps_runtime
+    if ! has_extension gd; then
+        compile_gd
+    fi
+}
+
+function compile_gd()
+{
     _gd_deps_build
 
     docker-php-ext-configure gd \

--- a/installer/stretch/extensions/gd.sh
+++ b/installer/stretch/extensions/gd.sh
@@ -6,6 +6,7 @@ function install_gd()
     if ! has_extension gd; then
         compile_gd
     fi
+    docker-php-ext-enable gd
 }
 
 function compile_gd()

--- a/installer/stretch/extensions/gmp.sh
+++ b/installer/stretch/extensions/gmp.sh
@@ -3,6 +3,13 @@
 function install_gmp()
 {
     _gmp_deps_runtime
+    if ! has_extension gmp; then
+        compile_gmp
+    fi
+}
+
+function compile_gmp()
+{
     _gmp_deps_build
 
     docker-php-ext-install gmp

--- a/installer/stretch/extensions/gmp.sh
+++ b/installer/stretch/extensions/gmp.sh
@@ -6,6 +6,7 @@ function install_gmp()
     if ! has_extension gmp; then
         compile_gmp
     fi
+    docker-php-ext-enable gmp
 }
 
 function compile_gmp()

--- a/installer/stretch/extensions/grpc.sh
+++ b/installer/stretch/extensions/grpc.sh
@@ -2,11 +2,16 @@
 
 function install_grpc()
 {
-    _grpc_deps_build
-
-    pecl install grpc
+    if ! has_extension grpc; then
+        compile_grpc
+    fi
     docker-php-ext-enable grpc
+}
 
+function compile_grpc()
+{
+    _grpc_deps_build
+    pecl install grpc
     _grpc_clean
 }
 

--- a/installer/stretch/extensions/igbinary.sh
+++ b/installer/stretch/extensions/igbinary.sh
@@ -2,6 +2,14 @@
 
 function install_igbinary()
 {
+    if ! has_extension igbinary; then
+        compile_igbinary
+    fi
+    docker-php-ext-enable igbinary
+}
+
+function compile_igbinary()
+{
     case "$VERSION" in
             "5.6")
                 printf "\n" | pecl install igbinary-2.0.8
@@ -9,5 +17,4 @@ function install_igbinary()
             *)
                 printf "\n" | pecl install igbinary
     esac
-    docker-php-ext-enable igbinary
 }

--- a/installer/stretch/extensions/imagick.sh
+++ b/installer/stretch/extensions/imagick.sh
@@ -34,5 +34,7 @@ function _imagick_clean_runtime()
 {
     remove \
       imagemagick \
-      libmagickwand-dev
+      libglib2.0-data \
+      libmagickwand-dev \
+      shared-mime-info
 }

--- a/installer/stretch/extensions/imagick.sh
+++ b/installer/stretch/extensions/imagick.sh
@@ -3,14 +3,36 @@
 function install_imagick()
 {
     _imagick_deps_runtime
+    if ! has_extension imagick; then
+        compile_imagick true
+    fi
+
+    docker-php-ext-enable imagick
+}
+
+function compile_imagick()
+{
+    local KEEP_DEPS="${1:-}"
+
+    _imagick_deps_runtime
 
     printf "\n" | pecl install imagick
-    docker-php-ext-enable imagick
+
+    if [ -z "$KEEP_DEPS" ]; then
+        _imagick_clean_runtime
+    fi
 }
 
 function _imagick_deps_runtime()
 {
     install \
+      imagemagick \
+      libmagickwand-dev
+}
+
+function _imagick_clean_runtime()
+{
+    remove \
       imagemagick \
       libmagickwand-dev
 }

--- a/installer/stretch/extensions/intl.sh
+++ b/installer/stretch/extensions/intl.sh
@@ -3,6 +3,14 @@
 function install_intl()
 {
     _intl_deps_runtime
+    if ! has_extension intl; then
+        compile_intl
+    fi
+    docker-php-ext-enable intl
+}
+
+function compile_intl()
+{
     _intl_deps_build
 
     docker-php-ext-install intl

--- a/installer/stretch/extensions/ldap.sh
+++ b/installer/stretch/extensions/ldap.sh
@@ -2,10 +2,18 @@
 
 function install_ldap()
 {
+    if ! has_extension ldap; then
+        compile_ldap
+    fi
+    docker-php-ext-enable ldap
+}
+
+function compile_ldap()
+{
     _ldap_deps_build
 
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
-    docker-php-ext-install ldap 
+    docker-php-ext-install ldap
 
     _ldap_clean
 }

--- a/installer/stretch/extensions/mcrypt.sh
+++ b/installer/stretch/extensions/mcrypt.sh
@@ -3,6 +3,14 @@
 function install_mcrypt()
 {
     _mcrypt_deps_runtime
+    if ! has_extension mcrypt; then
+        compile_mcrypt
+    fi
+    docker-php-ext-enable mcrypt
+}
+
+function compile_mcrypt()
+{
     _mcrypt_deps_build
 
     case "$VERSION" in
@@ -17,11 +25,9 @@ function install_mcrypt()
                 ;;
             "7.4")
                 printf "\n" | pecl install mcrypt-1.0.3
-                docker-php-ext-enable mcrypt
                 ;;
             *)
                 printf "\n" | pecl install mcrypt-1.0.2
-                docker-php-ext-enable mcrypt
     esac
 
     _mcrypt_clean

--- a/installer/stretch/extensions/mcrypt.sh
+++ b/installer/stretch/extensions/mcrypt.sh
@@ -35,7 +35,7 @@ function compile_mcrypt()
 
 function _mcrypt_deps_runtime()
 {
-    install libmcrypt4
+    install libmcrypt4 libltdl7
 }
 
 function _mcrypt_deps_build()

--- a/installer/stretch/extensions/memcached.sh
+++ b/installer/stretch/extensions/memcached.sh
@@ -3,6 +3,16 @@
 function install_memcached()
 {
     _memcached_deps_runtime
+
+    if ! has_extension memcached; then
+        compile_memcached
+    fi
+
+    docker-php-ext-enable memcached
+}
+
+function compile_memcached()
+{
     _memcached_deps_build
 
     case "$VERSION" in
@@ -12,8 +22,6 @@ function install_memcached()
             *)
                 printf "\n" | pecl install memcached
     esac
-
-    docker-php-ext-enable memcached
     _memcached_clean
 }
 

--- a/installer/stretch/extensions/newrelic.sh
+++ b/installer/stretch/extensions/newrelic.sh
@@ -11,3 +11,8 @@ function install_newrelic()
     /tmp/newrelic-php5-*/newrelic-install install
     rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
 }
+
+function compile_newrelic()
+{
+    :
+}

--- a/installer/stretch/extensions/pdo_pgsql.sh
+++ b/installer/stretch/extensions/pdo_pgsql.sh
@@ -3,6 +3,15 @@
 function install_pdo_pgsql()
 {
     _pdo_pgsql_deps_runtime
+
+    if ! has_extension pdo_pgsql; then
+        compile_pdo_pgsql
+    fi
+    docker-php-ext-enable pdo_pgsql
+}
+
+function compile_pdo_pgsql()
+{
     _pdo_pgsql_deps_build
 
     docker-php-ext-install pdo_pgsql

--- a/installer/stretch/extensions/pgsql.sh
+++ b/installer/stretch/extensions/pgsql.sh
@@ -3,6 +3,15 @@
 function install_pgsql()
 {
     _pgsql_deps_runtime
+
+    if ! has_extension pgsql; then
+        compile_pgsql
+    fi
+    docker-php-ext-enable pgsql
+}
+
+function compile_pgsql()
+{
     _pgsql_deps_build
 
     docker-php-ext-install pgsql

--- a/installer/stretch/extensions/protobuf.sh
+++ b/installer/stretch/extensions/protobuf.sh
@@ -2,6 +2,15 @@
 
 function install_protobuf()
 {
+    if ! has_extension protobuf; then
+        compile_protobuf
+    fi
+
+    docker-php-ext-enable protobuf
+}
+
+function compile_protobuf()
+{
     case "$VERSION" in
             "5.6")
                 printf "\n" | pecl install protobuf-3.12.4
@@ -9,6 +18,4 @@ function install_protobuf()
             *)
                 printf "\n" | pecl install protobuf
     esac
-
-    docker-php-ext-enable protobuf
 }

--- a/installer/stretch/extensions/protobuf.sh
+++ b/installer/stretch/extensions/protobuf.sh
@@ -2,6 +2,13 @@
 
 function install_protobuf()
 {
-    pecl install protobuf
+    case "$VERSION" in
+            "5.6")
+                printf "\n" | pecl install protobuf-3.12.4
+                ;;
+            *)
+                printf "\n" | pecl install protobuf
+    esac
+
     docker-php-ext-enable protobuf
 }

--- a/installer/stretch/extensions/rdkafka.sh
+++ b/installer/stretch/extensions/rdkafka.sh
@@ -3,10 +3,17 @@
 function install_rdkafka()
 {
     _rdkafka_deps_runtime
+    if ! has_extension rdkafka; then
+        compile_rdkafka
+    fi
+    docker-php-ext-enable rdkafka
+}
+
+function compile_rdkafka()
+{
     _rdkafka_deps_build
 
     pecl install rdkafka
-    docker-php-ext-enable rdkafka
 
     _rdkafka_clean
 }

--- a/installer/stretch/extensions/redis.sh
+++ b/installer/stretch/extensions/redis.sh
@@ -2,6 +2,14 @@
 
 function install_redis()
 {
+    if ! has_extension redis; then
+        compile_redis
+    fi
+    docker-php-ext-enable redis
+}
+
+function compile_redis()
+{
     case "$VERSION" in
             "5.6")
                 printf "\n" | pecl install -o -f redis-2.2.8
@@ -9,6 +17,4 @@ function install_redis()
             *)
                 printf "\n" | pecl install -o -f redis
     esac
-
-    docker-php-ext-enable redis
 }

--- a/installer/stretch/extensions/soap.sh
+++ b/installer/stretch/extensions/soap.sh
@@ -3,6 +3,14 @@
 function install_soap()
 {
     _soap_deps_runtime
+    if ! has_extension soap; then
+        compile_soap
+    fi
+    docker-php-ext-enable soap
+}
+
+function compile_soap()
+{
     _soap_deps_build
 
     docker-php-ext-install soap

--- a/installer/stretch/extensions/sockets.sh
+++ b/installer/stretch/extensions/sockets.sh
@@ -3,24 +3,19 @@
 function install_sockets()
 {
     _sockets_deps_runtime
+
+    if ! has_extension; then
+        compile_sockets
+    fi
+
+    docker-php-ext-enable sockets
+}
+
+function compile_sockets()
+{
     _sockets_deps_build
 
     docker-php-ext-install sockets
 
     _sockets_clean
-}
-
-function _sockets_deps_runtime()
-{
-    :
-}
-
-function _sockets_deps_build()
-{
-    :
-}
-
-function _sockets_clean()
-{
-    :
 }

--- a/installer/stretch/extensions/sockets.sh
+++ b/installer/stretch/extensions/sockets.sh
@@ -2,8 +2,6 @@
 
 function install_sockets()
 {
-    _sockets_deps_runtime
-
     if ! has_extension; then
         compile_sockets
     fi
@@ -13,9 +11,5 @@ function install_sockets()
 
 function compile_sockets()
 {
-    _sockets_deps_build
-
     docker-php-ext-install sockets
-
-    _sockets_clean
 }

--- a/installer/stretch/extensions/sodium.sh
+++ b/installer/stretch/extensions/sodium.sh
@@ -3,6 +3,16 @@
 function install_sodium()
 {
     _sodium_deps_runtime
+
+    if ! has_extension sodium; then
+        compile_sodium
+    fi
+
+    docker-php-ext-enable sodium
+}
+
+function compile_sodium()
+{
     _sodium_deps_build
 
     case "$VERSION" in

--- a/installer/stretch/extensions/sodium.sh
+++ b/installer/stretch/extensions/sodium.sh
@@ -8,7 +8,9 @@ function install_sodium()
         compile_sodium
     fi
 
-    docker-php-ext-enable sodium
+    if has_extension sodium; then
+        docker-php-ext-enable sodium
+    fi
 }
 
 function compile_sodium()

--- a/installer/stretch/extensions/ssh2.sh
+++ b/installer/stretch/extensions/ssh2.sh
@@ -2,6 +2,14 @@
 
 function install_ssh2()
 {
+    if ! has_extension ssh2; then
+        compile_ssh2
+    fi
+    docker-php-ext-enable ssh2
+}
+
+function compile_ssh2()
+{
     _ssh2_deps_build
     case "$VERSION" in
         "5.6")
@@ -11,8 +19,6 @@ function install_ssh2()
             # beta release, so need to specify version number
             printf "\n" | pecl install ssh2-1.2
     esac
-
-    docker-php-ext-enable ssh2
 
     _ssh2_clean
 }

--- a/installer/stretch/extensions/xdebug.sh
+++ b/installer/stretch/extensions/xdebug.sh
@@ -2,6 +2,15 @@
 
 function install_xdebug()
 (
+    if ! has_extension xdebug; then
+        compile_xdebug
+    fi
+
+    docker-php-ext-enable xdebug
+)
+
+function compile_xdebug()
+(
     set -o errexit -o pipefail
 
     local XDEBUG_PACKAGE="xdebug"
@@ -37,9 +46,5 @@ function install_xdebug()
                 ;&
             *)
                 printf "\n" | pecl install "$XDEBUG_PACKAGE"
-
-                docker-php-ext-enable xdebug
     esac
-
-    docker-php-ext-enable xdebug
 )

--- a/installer/stretch/extensions/xmlrpc.sh
+++ b/installer/stretch/extensions/xmlrpc.sh
@@ -2,10 +2,17 @@
 
 function install_xmlrpc()
 {
+    if ! has_extension xmlrpc; then
+        compile_xmlrpc
+    fi
+    docker-php-ext-enable xmlrpc
+}
+
+function compile_xmlrpc()
+{
     _xmlrpc_deps_build
 
     docker-php-ext-install xmlrpc
-    docker-php-ext-enable xmlrpc
 
     _xmlrpc_clean
 }

--- a/installer/stretch/extensions/xsl.sh
+++ b/installer/stretch/extensions/xsl.sh
@@ -3,6 +3,16 @@
 function install_xsl()
 {
     _xsl_deps_runtime
+
+    if ! has_extension xsl; then
+        compile_xsl
+    fi
+
+    docker-php-ext-enable xsl
+}
+
+function compile_xsl()
+{
     _xsl_deps_build
 
     docker-php-ext-install xsl

--- a/installer/stretch/extensions/zip.sh
+++ b/installer/stretch/extensions/zip.sh
@@ -3,6 +3,16 @@
 function install_zip()
 {
     _zip_deps_runtime
+
+    if ! has_extension zip; then
+        compile_zip
+    fi
+
+    docker-php-ext-enable zip
+}
+
+function compile_zip()
+{
     _zip_deps_build
 
     docker-php-ext-install zip

--- a/installer/stretch/lib/functions.sh
+++ b/installer/stretch/lib/functions.sh
@@ -35,10 +35,13 @@ function compile()
 
     if [ -f "$installer_file" ]; then
         # shellcheck source=../extensions/$installer_file
-        declare -F "$installer_name" &>/dev/null || source "$installer_file"
+        declare -F "$compile_name" &>/dev/null || source "$installer_file"
         "$compile_name"
     else
         docker-php-ext-install "$extension"
+    fi
+
+    if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-$extension.ini" ]; then
         rm "/usr/local/etc/php/conf.d/docker-php-ext-$extension.ini"
     fi
 }

--- a/installer/stretch/lib/functions.sh
+++ b/installer/stretch/lib/functions.sh
@@ -9,7 +9,9 @@ function enable()
         return
     fi
 
-    enable_without_check "$extension"
+    if ! enable_without_check "$extension"; then
+        return 1
+    fi
 }
 
 function enable_without_check()
@@ -21,9 +23,11 @@ function enable_without_check()
     if [ -f "$installer_file" ]; then
         # shellcheck source=../extensions/$installer_file
         declare -F "$installer_name" &>/dev/null || source "$installer_file"
-        $installer_name
-    else
-        docker-php-ext-install "$extension"
+        if ! "$installer_name"; then
+            return 1
+        fi
+    elif ! docker-php-ext-install "$extension"; then
+        return 1
     fi
 }
 
@@ -36,9 +40,11 @@ function compile()
     if [ -f "$installer_file" ]; then
         # shellcheck source=../extensions/$installer_file
         declare -F "$compile_name" &>/dev/null || source "$installer_file"
-        "$compile_name"
-    else
-        docker-php-ext-install "$extension"
+        if ! "$compile_name"; then
+            return 1
+        fi
+    elif ! docker-php-ext-install "$extension"; then
+        return 1
     fi
 
     if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-$extension.ini" ]; then

--- a/installer/stretch/lib/functions.sh
+++ b/installer/stretch/lib/functions.sh
@@ -27,6 +27,29 @@ function enable_without_check()
     fi
 }
 
+function compile()
+{
+    local extension="$1"
+    local installer_file="extensions/${extension}.sh"
+    local compile_name="compile_${extension}"
+
+    if [ -f "$installer_file" ]; then
+        # shellcheck source=../extensions/$installer_file
+        declare -F "$installer_name" &>/dev/null || source "$installer_file"
+        "$compile_name"
+    else
+        docker-php-ext-install "$extension"
+        rm "/usr/local/etc/php/conf.d/docker-php-ext-$extension.ini"
+    fi
+}
+
+function has_extension()
+{
+    local EXTENSION="$1"
+    test -f "$(php -r "echo ini_get('extension_dir');")/$EXTENSION.so"
+    return "$?"
+}
+
 function bootstrap()
 {
     echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends

--- a/installer/stretch/precompile.sh
+++ b/installer/stretch/precompile.sh
@@ -5,14 +5,17 @@ set -e
 export BUILD_DEPS=(autoconf g++ make)
 export BUILD_DEPS_CLEAN=()
 
+# shellcheck source=./lib/functions.sh
 source ./lib/functions.sh
 
 function main()
 {
     for extension in extensions/*
     do
+        extension_name="${extension%.sh}"
+        extension_name="${extension_name#extensions/}"
         echo -n "Installing ${extension}..."
-        compile "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1)
+        compile "$extension_name" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1)
         echo " success"
     done
 }

--- a/installer/stretch/precompile.sh
+++ b/installer/stretch/precompile.sh
@@ -22,6 +22,10 @@ function main()
         fi
         echo " success"
     done
+
+    if [ -f /tmp/ext-install.log ]; then
+        rm /tmp/ext-install.log
+    fi
 }
 
 VERSION="$(echo "$PHP_VERSION" | cut -c 1-3)"

--- a/installer/stretch/precompile.sh
+++ b/installer/stretch/precompile.sh
@@ -15,7 +15,11 @@ function main()
         extension_name="${extension%.sh}"
         extension_name="${extension_name#extensions/}"
         echo -n "Installing ${extension}..."
-        compile "$extension_name" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1)
+        if ! compile "$extension_name" > /tmp/ext-install.log 2>&1; then
+            echo " failure"
+            cat /tmp/ext-install.log
+            exit 1
+        fi
         echo " success"
     done
 }

--- a/installer/stretch/precompile.sh
+++ b/installer/stretch/precompile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -e -o pipefail
 
 export BUILD_DEPS=(autoconf g++ make)
 export BUILD_DEPS_CLEAN=()

--- a/installer/stretch/precompile.sh
+++ b/installer/stretch/precompile.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+export BUILD_DEPS=(autoconf g++ make)
+export BUILD_DEPS_CLEAN=()
+
+source ./lib/functions.sh
+
+function main()
+{
+    for extension in extensions/*
+    do
+        echo -n "Installing ${extension}..."
+        compile "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1)
+        echo " success"
+    done
+}
+
+VERSION="$(echo "$PHP_VERSION" | cut -c 1-3)"
+export VERSION
+
+bootstrap
+main
+clean

--- a/installer/stretch/reenable.sh
+++ b/installer/stretch/reenable.sh
@@ -12,6 +12,7 @@ function main()
 {
     for extension in "$@"
     do
+        compile "$extension"
         enable_without_check "$extension"
     done
 }

--- a/installer/stretch/reenable.sh
+++ b/installer/stretch/reenable.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -x
+set -e -o pipefail -x
 
 export BUILD_DEPS=(autoconf g++ make)
 export BUILD_DEPS_CLEAN=()

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+cd /root/installer/
+
+for extension in extensions/*; do
+    echo -n "Installing ${extension}..."
+    extension_name="${extension%.sh}"
+    extension_name="${extension_name#extensions/}"
+    if ! ./enable.sh "$extension_name" > /tmp/ext-install.log 2>&1; then
+        echo ' failure'
+        cat /tmp/ext-install.log
+        exit 1
+    fi
+    if [ "$extension_name" = 'blackfire' ] || [ "$extension" = 'tideways' ]; then
+        echo ' success'
+        continue
+    fi
+    if php -m | grep -i -q "^$extension_name\$"; then
+        echo ' success'
+        continue
+    fi
+    echo ' failure'
+    echo "Could not find extension in php module list:"
+    php -m
+    exit 1
+done
+
+php -m
+php -v

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -4,6 +4,8 @@ set -e
 
 cd /root/installer/
 
+VERSION="$(echo "$PHP_VERSION" | cut -c 1,3)"
+
 before="$(php -m)$(php -v)"
 echo "Before: $before"
 
@@ -16,7 +18,13 @@ for extension in extensions/*; do
         cat /tmp/ext-install.log
         exit 1
     fi
-    if [ "$extension_name" = 'blackfire' ] || [ "$extension" = 'tideways' ]; then
+    # These extensions aren't enabled by default
+    if [ "$extension_name" = 'blackfire' ] || [ "$extension_name" = "newrelic" ] [ "$extension_name" = 'tideways' ]; then
+        echo ' success'
+        continue
+    fi
+    # Sodium only available for PHP 7.2+
+    if  [ "$extension_name" = 'sodium' ] && [ "$VERSION" -lt 72 ]; then
         echo ' success'
         continue
     fi

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -4,6 +4,9 @@ set -e
 
 cd /root/installer/
 
+before="$(php -m)$(php -v)"
+echo "Before: $before"
+
 for extension in extensions/*; do
     echo -n "Installing ${extension}..."
     extension_name="${extension%.sh}"
@@ -27,5 +30,6 @@ for extension in extensions/*; do
     exit 1
 done
 
-php -m
-php -v
+after="$(php -m)$(php -v)"
+echo "After: $after"
+diff <(echo "$before") <(echo "$after")

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -19,7 +19,7 @@ for extension in extensions/*; do
         exit 1
     fi
     # These extensions aren't enabled by default
-    if [ "$extension_name" = 'blackfire' ] || [ "$extension_name" = "newrelic" ] [ "$extension_name" = 'tideways' ]; then
+    if [ "$extension_name" = 'blackfire' ] || [ "$extension_name" = "newrelic" ] || [ "$extension_name" = 'tideways' ]; then
         echo ' success'
         continue
     fi
@@ -39,5 +39,5 @@ for extension in extensions/*; do
 done
 
 after="$(php -m)$(php -v)"
-echo "After: $after"
-diff <(echo "$before") <(echo "$after")
+echo "After: $after\nDiff:"
+diff -u <(echo "$before") <(echo "$after") || true

--- a/test.sh
+++ b/test.sh
@@ -7,8 +7,7 @@ BUILD="${BUILD:-}"
 for service in $(docker-compose config --services | grep -E "${BUILD}" | grep base); do
   echo
   echo "Testing service ${service}"
-  # shellcheck disable=SC2016
-  docker-compose run --rm "$service" bash -e -c 'cd /root/installer/; for extension in extensions/*; do echo -n "Installing ${extension}..."; ./enable.sh "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1); if [ "$extension" != "extensions/tideways.sh" ] && [ "$extension" != "extensions/blackfire.sh" ]; then php -m | grep -i "^$extension\$"; fi; echo " success"; done; php -m; php -v'
+  docker-compose run --rm -v "$(pwd)/test.extensions.sh:/app/test.extensions.sh" "$service" /app/test.extensions.sh
 done
 
 for service in $(docker-compose config --services | grep -E "${BUILD}" | grep console); do

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ for service in $(docker-compose config --services | grep -E "${BUILD}" | grep ba
   echo
   echo "Testing service ${service}"
   # shellcheck disable=SC2016
-  docker-compose run --rm "$service" bash -e -c 'cd /root/installer/; for extension in extensions/*; do echo -n "Installing ${extension}..."; ./enable.sh "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1); php -m | grep -i "^$extension$"; echo " success"; done; php -m; php -v'
+  docker-compose run --rm "$service" bash -e -c 'cd /root/installer/; for extension in extensions/*; do echo -n "Installing ${extension}..."; ./enable.sh "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1); if [ "$extension" != "extensions/tideways.sh" ] && [ "$extension" != "extensions/blackfire.sh" ]; then php -m | grep -i "^$extension\$"; fi; echo " success"; done; php -m; php -v'
 done
 
 for service in $(docker-compose config --services | grep -E "${BUILD}" | grep console); do

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ for service in $(docker-compose config --services | grep -E "${BUILD}" | grep ba
   echo
   echo "Testing service ${service}"
   # shellcheck disable=SC2016
-  docker-compose run --rm "$service" bash -e -c 'cd /root/installer/; for extension in extensions/*; do echo -n "Installing ${extension}..."; ./enable.sh "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1); echo " success"; done; php -m; php -v'
+  docker-compose run --rm "$service" bash -e -c 'cd /root/installer/; for extension in extensions/*; do echo -n "Installing ${extension}..."; ./enable.sh "$(expr match "$extension" "extensions/\(.*\).sh")" > /tmp/ext-install.log 2>&1 || (echo " failure" && cat /tmp/ext-install.log && exit 1); php -m | grep -i "^$extension$"; echo " success"; done; php -m; php -v'
 done
 
 for service in $(docker-compose config --services | grep -E "${BUILD}" | grep console); do


### PR DESCRIPTION
Brings in #37 and #39.

Pre-compile extensions to improve build speed on projects when extra extensions are needed.

Adds 90MB to the base image, with 68M being for grpc.so:
```bash
docker images | grep 7.2-fpm-stretch
php                                              7.2-fpm-stretch                                    cafbe9ef6dba        13 days ago         364MB
my127/php                                        7.2-fpm-stretch-upstream                           eb87c2d17825        26 hours ago        405MB
my127/php                                        7.2-fpm-stretch                                    800b286d4a5f        9 minutes ago       495MB
```

Unfortunately grpc is also the slowest to build, so has the most gain to be pre-compiled!