### PR TITLE
Fix PHP 5.6 GRPC extension build failure

### DIFF
--- a/installer/stretch/extensions/grpc.sh
+++ b/installer/stretch/extensions/grpc.sh
@@ -14,8 +14,8 @@ function compile_grpc()
 
     PACKAGE_NAME="grpc"
     case "$VERSION" in
-            "8.0")
-                PACKAGE_NAME="grpc-1.34.0RC2"
+            "5.6")
+                PACKAGE_NAME="grpc-1.33.1"
                 ;;
     esac
 

--- a/installer/stretch/extensions/mysqli.sh
+++ b/installer/stretch/extensions/mysqli.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+function install_mysqli()
+{
+    _mysqli_deps_runtime
+
+    if ! has_extension mysqli; then
+        compile_mysqli
+    fi
+    docker-php-ext-enable mysqli
+}
+
+function compile_mysqli()
+{
+    _mysqli_deps_build
+
+    docker-php-ext-install mysqli
+
+    _mysqli_clean
+}
+
+function _mysqli_deps_runtime()
+{
+    :
+}
+
+function _mysqli_deps_build()
+{
+    :
+}
+
+function _mysqli_clean()
+{
+    :
+}


### PR DESCRIPTION
Latest version no longer supports PHP 5.x, but does support 8.0, so we can invert the case statement.