### PR TITLE
Add the latest redis-cli from the same base OS version as the image

### DIFF
--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -1,11 +1,14 @@
 ARG VERSION=7.3
 ARG BASEOS=stretch
+ARG REDIS_VERSION=6.2
+
+FROM redis:${REDIS_VERSION}-${BASEOS} as redis
+
 FROM my127/php:${VERSION}-fpm-${BASEOS}
 # upstream is SIGQUIT, cli should be SIGTERM
 STOPSIGNAL SIGTERM
 
 ARG BASEOS
-ARG REDIS_VERSION=6.2
 ENV IMAGE_TYPE=console
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
@@ -38,7 +41,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && rm -rf /var/lib/apt/lists/* \
  && for i in $(seq 1 8); do rm -rf "/usr/share/man/man$i"; done
 
-COPY --from=redis:${REDIS_VERSION}-${BASEOS} /usr/local/bin/redis-cli /usr/local/bin/redis-cli
+COPY --from=redis /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 
 # User: build
 # -----------

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -8,7 +8,6 @@ FROM my127/php:${VERSION}-fpm-${BASEOS}
 # upstream is SIGQUIT, cli should be SIGTERM
 STOPSIGNAL SIGTERM
 
-ARG BASEOS
 ENV IMAGE_TYPE=console
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -4,7 +4,8 @@ FROM my127/php:${VERSION}-fpm-${BASEOS}
 # upstream is SIGQUIT, cli should be SIGTERM
 STOPSIGNAL SIGTERM
 
-ARG BASEOS=stretch
+ARG BASEOS
+ARG REDIS_VERSION=6.2
 ENV IMAGE_TYPE=console
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
@@ -36,6 +37,8 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && for i in $(seq 1 8); do rm -rf "/usr/share/man/man$i"; done
+
+COPY --from=redis:${REDIS_VERSION}-${BASEOS} /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 
 # User: build
 # -----------

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -8,6 +8,7 @@ FROM my127/php:${VERSION}-fpm-${BASEOS}
 # upstream is SIGQUIT, cli should be SIGTERM
 STOPSIGNAL SIGTERM
 
+ARG BASEOS
 ENV IMAGE_TYPE=console
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       dockerfile: base.Dockerfile
       args:
         VERSION: 5.6
+        REDIS_VERSION: 5.0
         BASEOS: stretch
 
   php70-fpm-stretch-base:
@@ -20,6 +21,7 @@ services:
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.0
+        REDIS_VERSION: 5.0
         BASEOS: stretch
 
   php71-fpm-stretch-base:
@@ -29,6 +31,7 @@ services:
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.1
+        REDIS_VERSION: 5.0
         BASEOS: stretch
 
   php72-fpm-stretch-base:
@@ -38,6 +41,7 @@ services:
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.2
+        REDIS_VERSION: 5.0
         BASEOS: stretch
 
   php73-fpm-stretch-base:
@@ -47,6 +51,7 @@ services:
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.3
+        REDIS_VERSION: 5.0
         BASEOS: stretch
 
   php73-fpm-buster-base:
@@ -85,6 +90,7 @@ services:
       dockerfile: console.Dockerfile
       args:
         VERSION: 5.6
+        REDIS_VERSION: 5.0
         BASEOS: stretch
     depends_on:
       - php56-fpm-stretch-base
@@ -96,6 +102,7 @@ services:
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.0
+        REDIS_VERSION: 5.0
         BASEOS: stretch
     depends_on:
       - php70-fpm-stretch-base
@@ -107,6 +114,7 @@ services:
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.1
+        REDIS_VERSION: 5.0
         BASEOS: stretch
     depends_on:
       - php71-fpm-stretch-base
@@ -118,6 +126,7 @@ services:
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.2
+        REDIS_VERSION: 5.0
         BASEOS: stretch
     depends_on:
       - php72-fpm-stretch-base
@@ -129,6 +138,7 @@ services:
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.3
+        REDIS_VERSION: 5.0
         BASEOS: stretch
     depends_on:
       - php73-fpm-stretch-base


### PR DESCRIPTION
Stretch stopped at 5.0, and 6.2 is the latest release