### PR TITLE
Add msmtp to avoid DNS issues with mhsendmail

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -15,6 +15,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
    ca-certificates \
    gettext-base \
    iproute2 \
+   msmtp \
    supervisor \
   # clean \
  && apt-get auto-remove -qq -y \


### PR DESCRIPTION
@elvetemedve is having issues with mhsendmail resolving `mailhog-relay` incorrectly due to being compiled with an older go version and not picking up on docker's `options nodots:0` in resolv.conf

Using msmtp allows us to bypass this issue.