### PR TITLE
Use buildkit for building and keeping apt cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 pipeline {
     agent none
+    environment {
+        COMPOSE_DOCKER_CLI_BUILD = 1
+        DOCKER_BUILDKIT = 1
+    }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
         parallelsAlwaysFailFast()

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.2
 ARG VERSION=7.3
 ARG BASEOS=stretch
 FROM php:${VERSION}-fpm-${BASEOS}
@@ -6,7 +7,9 @@ FROM php:${VERSION}-fpm-${BASEOS}
 # ---
 ARG BASEOS=stretch
 ENV IMAGE_TYPE=base
-RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+ echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && if [ "$VERSION" != "5.6" ] && [ "$VERSION" != "7.0" ] && [ "$VERSION" != "7.1" ] && [ "$BASEOS" = "stretch" ]; then echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list; fi \
  && apt-get update -qq \
@@ -19,8 +22,6 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
    supervisor \
   # clean \
  && apt-get auto-remove -qq -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
  && curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
@@ -30,7 +31,10 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
 # ---
 COPY installer/stretch /root/installer
 COPY "installer/$BASEOS" /root/installer
-RUN cd /root/installer; ./precompile.sh \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+ export CLEAN_SKIP_APT_CACHE=true \
+ && cd /root/installer; ./precompile.sh \
  && ./enable.sh \
   bcmath \
   gd \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,78 +8,102 @@ services:
     image: my127/php:5.6-fpm-stretch
     build:
       context: ./
+      cache_from:
+        - my127/php:5.6-fpm-stretch
       dockerfile: base.Dockerfile
       args:
         VERSION: 5.6
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
 
   php70-fpm-stretch-base:
     image: my127/php:7.0-fpm-stretch
     build:
       context: ./
+      cache_from:
+        - my127/php:7.0-fpm-stretch
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.0
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
 
   php71-fpm-stretch-base:
     image: my127/php:7.1-fpm-stretch
     build:
       context: ./
+      cache_from:
+        - my127/php:7.1-fpm-stretch
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.1
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
 
   php72-fpm-stretch-base:
     image: my127/php:7.2-fpm-stretch
     build:
       context: ./
+      cache_from:
+        - my127/php:7.1-fpm-stretch
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.2
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
 
   php73-fpm-stretch-base:
     image: my127/php:7.3-fpm-stretch
     build:
       context: ./
+      cache_from:
+        - php73-fpm-stretch-base
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.3
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
 
   php73-fpm-buster-base:
     image: my127/php:7.3-fpm-buster
     build:
       context: ./
+      cache_from:
+        - my127/php:7.3-fpm-buster
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.3
         BASEOS: buster
+        BUILDKIT_INLINE_CACHE: 1
 
   php74-fpm-buster-base:
     image: my127/php:7.4-fpm-buster
     build:
       context: ./
+      cache_from:
+        - my127/php:7.4-fpm-buster
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.4
         BASEOS: buster
+        BUILDKIT_INLINE_CACHE: 1
 
   php80-fpm-buster-base:
     image: my127/php:8.0-fpm-buster
     build:
       context: ./
+      cache_from:
+        - my127/php:8.0-fpm-buster
       dockerfile: base.Dockerfile
       args:
         VERSION: 8.0
         BASEOS: buster
+        BUILDKIT_INLINE_CACHE: 1
 
   # Console Images
 
@@ -87,11 +111,14 @@ services:
     image: my127/php:5.6-fpm-stretch-console
     build:
       context: ./
+      cache_from:
+        - my127/php:5.6-fpm-stretch-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 5.6
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php56-fpm-stretch-base
 
@@ -99,11 +126,14 @@ services:
     image: my127/php:7.0-fpm-stretch-console
     build:
       context: ./
+      cache_from:
+        - my127/php:7.0-fpm-stretch-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.0
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php70-fpm-stretch-base
 
@@ -111,11 +141,14 @@ services:
     image: my127/php:7.1-fpm-stretch-console
     build:
       context: ./
+      cache_from:
+        - my127/php:7.1-fpm-stretch-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.1
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php71-fpm-stretch-base
 
@@ -123,11 +156,14 @@ services:
     image: my127/php:7.2-fpm-stretch-console
     build:
       context: ./
+      cache_from:
+        - my127/php:7.2-fpm-stretch-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.2
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php72-fpm-stretch-base
 
@@ -135,11 +171,14 @@ services:
     image: my127/php:7.3-fpm-stretch-console
     build:
       context: ./
+      cache_from:
+        - my127/php:7.3-fpm-stretch-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.3
         REDIS_VERSION: 5.0
         BASEOS: stretch
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php73-fpm-stretch-base
 
@@ -147,10 +186,13 @@ services:
     image: my127/php:7.3-fpm-buster-console
     build:
       context: ./
+      cache_from:
+        - my127/php:7.3-fpm-buster-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.3
         BASEOS: buster
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php73-fpm-buster-base
 
@@ -158,10 +200,13 @@ services:
     image: my127/php:7.4-fpm-buster-console
     build:
       context: ./
+      cache_from: 
+        - my127/php:7.4-fpm-buster-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.4
         BASEOS: buster
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php74-fpm-buster-base
 
@@ -169,9 +214,12 @@ services:
     image: my127/php:8.0-fpm-buster-console
     build:
       context: ./
+      cache_from: 
+        - my127/php:8.0-fpm-buster-console
       dockerfile: console.Dockerfile
       args:
         VERSION: 8.0
         BASEOS: buster
+        BUILDKIT_INLINE_CACHE: 1
     depends_on:
       - php80-fpm-buster-base

--- a/installer/stretch/lib/functions.sh
+++ b/installer/stretch/lib/functions.sh
@@ -83,9 +83,12 @@ function clean()
     done
 
     apt-get auto-remove -qq -y
-    apt-get clean
 
-    rm -rf /var/lib/apt/lists/*
+    if [ "${CLEAN_SKIP_APT_CACHE:-}" != true ]; then
+        apt-get clean
+
+        rm -rf /var/lib/apt/lists/*
+    fi
 }
 
 function install()


### PR DESCRIPTION
buildkit will package the build and apt cache along with the image in the same repository. It wouldn't cause the image pull later to fetch that cache when used as a normal image though, so effectively makes a distributed cache