### PR TITLE
Add php 8.1 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG BASEOS=stretch
 ENV IMAGE_TYPE=base
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
- && if [ "$VERSION" != "5.6" ] && [ "$VERSION" != "7.0" ] && [ "$VERSION" != "7.1" ] && [ "$BASEOS" = "stretch" ]; then \
+ && if [ "$BASEOS" = "stretch" ]; then \
    apt-get update -qq \
    && echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list \
    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
@@ -45,12 +45,12 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
 # ---
 COPY installer/stretch /root/installer
 COPY "installer/$BASEOS" /root/installer
-RUN cd /root/installer; ./precompile.sh \
- && ./enable.sh \
+RUN cd /root/installer; ./precompile.sh
+RUN cd /root/installer; ./enable.sh \
   bcmath \
   gd \
   intl \
-  mcrypt \
+  $(dpkg --compare-versions "${PHP_VERSION}" ge 8.1 || echo mcrypt) \
   opcache \
   pdo_mysql \
   pdo_pgsql \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                 axes {
                     axis {
                         name 'BUILD'
-                        values 'php56|php70', 'php71|php72', 'php73|php74', 'php80'
+                        values 'php56|php70', 'php71|php72', 'php73|php74', 'php80|php81'
                     }
                     axis {
                         name 'PLATFORM'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,15 @@ services:
         VERSION: 8.0
         BASEOS: bullseye
 
+  php81-fpm-bullseye-base:
+    image: my127/php:8.1-fpm-bullseye${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: base
+      args:
+        VERSION: 8.1
+        BASEOS: bullseye
+
   # Console Images
 
   php56-fpm-stretch-console:
@@ -216,3 +225,14 @@ services:
         BASEOS: bullseye
     depends_on:
       - php80-fpm-bullseye-base
+
+  php81-fpm-bullseye-console:
+    image: my127/php:8.1-fpm-bullseye-console${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: console
+      args:
+        VERSION: 8.1
+        BASEOS: bullseye
+    depends_on:
+      - php81-fpm-bullseye-base

--- a/installer/stretch/extensions/mcrypt.sh
+++ b/installer/stretch/extensions/mcrypt.sh
@@ -23,8 +23,12 @@ function compile_mcrypt()
         "7.1")
             docker-php-ext-install mcrypt
             ;;
-        *)
+        "7.*|8.0")
             printf "\n" | pecl install mcrypt
+            ;;
+        *)
+            echo "mcrypt is not supported by PHP ${VERSION}" >&2
+            ;;
     esac
 
     _mcrypt_clean

--- a/installer/stretch/extensions/mcrypt.sh
+++ b/installer/stretch/extensions/mcrypt.sh
@@ -16,14 +16,14 @@ function compile_mcrypt()
     _mcrypt_deps_build
 
     case "$VERSION" in
-        "5.6")
+        5.6)
             ;&
-        "7.0")
+        7.0)
             ;&
-        "7.1")
+        7.1)
             docker-php-ext-install mcrypt
             ;;
-        "7.*|8.0")
+        7.*|8.0)
             printf "\n" | pecl install mcrypt
             ;;
         *)

--- a/installer/stretch/extensions/xdebug.sh
+++ b/installer/stretch/extensions/xdebug.sh
@@ -40,7 +40,7 @@ function compile_xdebug()
                 popd
 
                 ;;
-            "7.1")
+            "7.0")
                 XDEBUG_PACKAGE="xdebug-2.8.1"
                 printf "\n" | pecl install "$XDEBUG_PACKAGE"
                 ;;

--- a/installer/stretch/extensions/xdebug.sh
+++ b/installer/stretch/extensions/xdebug.sh
@@ -13,7 +13,6 @@ function compile_xdebug()
 (
     set -o errexit -o pipefail
 
-    local XDEBUG_PACKAGE="xdebug-2.9.8"
     case "$VERSION" in
             "5.6")
                 XDEBUG_PACKAGE="xdebug-2.5.5"
@@ -41,14 +40,16 @@ function compile_xdebug()
                 popd
 
                 ;;
-            "7.0")
+            "7.1")
                 XDEBUG_PACKAGE="xdebug-2.8.1"
                 printf "\n" | pecl install "$XDEBUG_PACKAGE"
                 ;;
-            "8.0")
-                XDEBUG_PACKAGE="xdebug"
-                ;&
+            "7.*")
+                XDEBUG_PACKAGE="xdebug-2.9.8"
+                printf "\n" | pecl install "$XDEBUG_PACKAGE"
+                ;;
             *)
+                XDEBUG_PACKAGE="xdebug"
                 printf "\n" | pecl install "$XDEBUG_PACKAGE"
     esac
 )

--- a/installer/stretch/extensions/xdebug.sh
+++ b/installer/stretch/extensions/xdebug.sh
@@ -14,7 +14,7 @@ function compile_xdebug()
     set -o errexit -o pipefail
 
     case "$VERSION" in
-            "5.6")
+            5.6)
                 XDEBUG_PACKAGE="xdebug-2.5.5"
                 # Build xdebug manually to avoid a debian compiler bug
                 # https://github.com/docker-library/php/issues/133
@@ -40,11 +40,11 @@ function compile_xdebug()
                 popd
 
                 ;;
-            "7.0")
+            7.0)
                 XDEBUG_PACKAGE="xdebug-2.8.1"
                 printf "\n" | pecl install "$XDEBUG_PACKAGE"
                 ;;
-            "7.*")
+            7.*)
                 XDEBUG_PACKAGE="xdebug-2.9.8"
                 printf "\n" | pecl install "$XDEBUG_PACKAGE"
                 ;;

--- a/installer/stretch/extensions/xmlrpc.sh
+++ b/installer/stretch/extensions/xmlrpc.sh
@@ -13,7 +13,7 @@ function compile_xmlrpc()
     _xmlrpc_deps_build
 
     case "$VERSION" in
-        "8.*")
+        8.*)
             printf "\n" | pecl install xmlrpc-1.0.0RC3
             ;;
         *)

--- a/installer/stretch/extensions/xmlrpc.sh
+++ b/installer/stretch/extensions/xmlrpc.sh
@@ -13,8 +13,8 @@ function compile_xmlrpc()
     _xmlrpc_deps_build
 
     case "$VERSION" in
-        "8.0")
-            printf "\n" | pecl install xmlrpc-1.0.0RC2
+        "8.*")
+            printf "\n" | pecl install xmlrpc-1.0.0RC3
             ;;
         *)
             docker-php-ext-install xmlrpc

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -4,7 +4,7 @@ set -e
 
 cd /root/installer/
 
-VERSION="$(echo "$PHP_VERSION" | cut -c 1,3)"
+alias version_compare=dpkg --compare-versions
 
 before="$(php -m)$(php -v)"
 echo "Before: $before"
@@ -15,17 +15,23 @@ for extension in extensions/*; do
     extension_name="${extension_name#extensions/}"
 
     # These extensions aren't compiled for PHP 5.6
-    if  [ "$extension_name" = 'mongodb' ] && [ "$VERSION" -lt 70 ]; then
+    if  [ "$extension_name" = 'mongodb' ] && version_compare "$PHP_VERSION" lt 7.0; then
         echo ' skipped'
         continue
     fi
     # Sodium only available for PHP 7.2+
-    if  [ "$extension_name" = 'sodium' ] && [ "$VERSION" -lt 72 ]; then
+    if  [ "$extension_name" = 'sodium' ] && version_compare "$PHP_VERSION" lt 7.2; then
         echo ' skipped'
         continue
     fi
     # Some extensions only available for PHP <8.0
-    if  [[ "$extension_name" = 'protobuf' || "$extension_name" = 'ssh2' ]] && [ "$VERSION" -ge 80 ]; then
+    if  [[ "$extension_name" = 'protobuf' || "$extension_name" = 'ssh2' ]] && version_compare "$PHP_VERSION" ge 8.0; then
+        echo ' skipped'
+        continue
+    fi
+
+    # Some extensions only available for PHP <8.1
+    if  [[ "$extension_name" = 'mcrypt' ]] && version_compare "$PHP_VERSION" ge 8.1; then
         echo ' skipped'
         continue
     fi

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -4,7 +4,9 @@ set -e
 
 cd /root/installer/
 
-alias version_compare='dpkg --compare-versions'
+function version_compare() {
+    dpkg --compare-versions "$@"
+}
 
 before="$(php -m)$(php -v)"
 echo "Before: $before"

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -4,7 +4,7 @@ set -e
 
 cd /root/installer/
 
-alias version_compare=dpkg --compare-versions
+alias version_compare='dpkg --compare-versions'
 
 before="$(php -m)$(php -v)"
 echo "Before: $before"


### PR DESCRIPTION
* mcrypt extension doesn't support PHP 8.1 (yet?)
* some fixes to make all 8.* versions install the same version of extensions
* xmlrpc upgraded to latest RC for 8.*
* Some refactoring to support comparisons with PHP_VERSION directly
* Removal of the version check for stretch backports, which wasn't matching correctly at any point