### PR TITLE
Add libmariadb3 for mariadb client's support for mysql server 8 caching_sha2_password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
    git \
    iproute2 \
    jq \
+   $([ "${BASEOS}" = stretch ] || echo libmariadb3) \
    nano \
    nasm \
    openssh-client \


### PR DESCRIPTION
So that we don't need to install mysql client for compatibility