### PR TITLE
Fix tideways module already enabled warning

### DIFF
--- a/installer/stretch/extensions/tideways.sh
+++ b/installer/stretch/extensions/tideways.sh
@@ -21,6 +21,8 @@ function _tideways_deps_runtime()
     install \
       tideways-php \
       "$CLI_PACKAGE"
+
+    rm -f /usr/local/etc/php/conf.d/tideways.ini || true
 }
 
 function _tideways_deps_build()


### PR DESCRIPTION
The tideways-php package now bundles `/usr/local/etc/php/conf.d/tideways.ini` containing:
```ini
extension=tideways.so
```

This conflicts with the way the harness handles if we want tideways enabled or not, which is to manage the file /usr/local/etc/php/conf.d/docker-php-ext-tideways.ini with [this twig file](https://github.com/inviqa/harness-base-php/blob/ae099e17dfc0b75c626ab4fe6a3420f5490a8ca0/src/_base/docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini.twig)

When enabled in the harness's way we end up with the PHP CLI saying:
```
PHP Warning:  Module 'tideways' already loaded in Unknown on line 0
```
upon each invocation