### PR TITLE
Fix protobuf extension build

### DIFF
--- a/installer/stretch/extensions/protobuf.sh
+++ b/installer/stretch/extensions/protobuf.sh
@@ -26,6 +26,6 @@ function compile_protobuf()
             printf "\n" | pecl install protobuf-3.12.4
             ;;
         *)
-            printf "\n" | pecl install protobuf
+            printf "\n" | pecl install protobuf-3.20.1RC1
     esac
 }


### PR DESCRIPTION
Use https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.1-rc1
instead of the broken installation for
https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0