### PR TITLE
Replace deleted debian stretch apt sources with archive versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,13 @@ RUN <<EOF
   echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends
   echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends
   if [ "$BASEOS" = "stretch" ]; then
+    cat <<EOD > /etc/apt/sources.list
+deb http://archive.debian.org/debian stretch main
+deb http://archive.debian.org/debian-security stretch/updates main
+deb http://archive.debian.org/debian stretch-updates main
+EOD
     apt-get update -qq
-    echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list
+    echo 'deb http://archive.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list
     # key receive dependencies
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
       dirmngr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN <<EOF
     cat <<EOD > /etc/apt/sources.list
 deb http://archive.debian.org/debian stretch main
 deb http://archive.debian.org/debian-security stretch/updates main
-deb http://archive.debian.org/debian stretch-updates main
 EOD
     apt-get update -qq
     echo 'deb http://archive.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list


### PR DESCRIPTION
Stretch has moved to archive