### PR TITLE
Limit grpc extension version for distribution versions before buster

### DIFF
--- a/installer/stretch/extensions/grpc.sh
+++ b/installer/stretch/extensions/grpc.sh
@@ -20,7 +20,7 @@ function compile_grpc()
     *)
         case "$BASEOS" in
         stretch)
-            PACKAGE_NAME="grpc-1.53.0"
+            PACKAGE_NAME="grpc-1.52.1"
             ;;
         esac     
     esac

--- a/installer/stretch/extensions/grpc.sh
+++ b/installer/stretch/extensions/grpc.sh
@@ -19,7 +19,7 @@ function compile_grpc()
         ;;
     *)
         case "$BASEOS" in
-        stretch|buster)
+        stretch)
             PACKAGE_NAME="grpc-1.53.0"
             ;;
         esac     

--- a/installer/stretch/extensions/grpc.sh
+++ b/installer/stretch/extensions/grpc.sh
@@ -14,9 +14,15 @@ function compile_grpc()
 
     PACKAGE_NAME="grpc"
     case "$VERSION" in
-            "5.6")
-                PACKAGE_NAME="grpc-1.33.1"
-                ;;
+    "5.6")
+        PACKAGE_NAME="grpc-1.33.1"
+        ;;
+    *)
+        case "$BASEOS" in
+        stretch|buster)
+            PACKAGE_NAME="grpc-1.53.0"
+            ;;
+        esac     
     esac
 
     pecl install "$PACKAGE_NAME"


### PR DESCRIPTION
grpc-1.5.4 requires a later version of GCC than they provide