### PR TITLE
Improve reliability of gpg key import by turning off IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ EOD
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
       dirmngr \
       gnupg2
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138 0E98404D386FA1D9
+    export GNUPGHOME="$(mktemp -d)"
+    echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf"
+    apt-key adv --homedir "$GNUPGHOME" --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138 0E98404D386FA1D9
+    rm -rf "$GNUPGHOME"
   fi
   apt-get update -qq
   apt-get upgrade -qq -y


### PR DESCRIPTION
Helps even if the networking stack doesn't use it. I was seeing 50% failure rate on the apt-key step of:

```bash
docker run --rm -it php:5.6-fpm-stretch bash
apt-get update -qq
echo 'deb http://archive.debian.org/debian stretch-backports main' >> /etc/apt/sources.list.d/stetch-backports.list
DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
      dirmngr \
      gnupg2
apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138 0E98404D386FA1D9
```

Fix discussed in https://github.com/usbarmory/usbarmory-debian-base_image/issues/9