### PR TITLE
Add PHP 8.3 with redis 7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cd /root/installer; ./enable.sh \
   bcmath \
   gd \
   intl \
-  mcrypt \
+  "$(dpkg --compare-versions "$PHP_VERSION" ge 8.3 || echo mcrypt )" \
   opcache \
   pdo_mysql \
   pdo_pgsql \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,7 @@ pipeline {
                 axes {
                     axis {
                         name 'BUILD'
-                        // values 'php56|php70', 'php71|php72', 'php73|php74', 'php80|php81', 'php82'
-                        values 'php83'
+                        values 'php56|php70', 'php71|php72', 'php73|php74', 'php80|php81', 'php82|php83'
                     }
                     axis {
                         name 'PLATFORM'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,8 @@ pipeline {
                 axes {
                     axis {
                         name 'BUILD'
-                        values 'php56|php70', 'php71|php72', 'php73|php74', 'php80|php81', 'php82'
+                        // values 'php56|php70', 'php71|php72', 'php73|php74', 'php80|php81', 'php82'
+                        values 'php83'
                     }
                     axis {
                         name 'PLATFORM'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,16 @@ services:
         NODE_VERSION: 10
         BASEOS: bookworm
 
+  php83-fpm-bookworm-base:
+    image: my127/php:8.3-fpm-bookworm${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: base
+      args:
+        VERSION: 8.3
+        REDIS_VERSION: 7.2
+        BASEOS: bookworm
+
   # Console Images
 
   php56-fpm-stretch-console:
@@ -295,4 +305,14 @@ services:
       args:
         VERSION: 8.2
         NODE_VERSION: 10
+        BASEOS: bookworm
+
+  php83-fpm-bookworm-console:
+    image: my127/php:8.3-fpm-bookworm-console${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: console
+      args:
+        VERSION: 8.3
+        REDIS_VERSION: 7.2
         BASEOS: bookworm

--- a/installer/base/extensions/imagick.sh
+++ b/installer/base/extensions/imagick.sh
@@ -2,6 +2,13 @@
 
 function install_imagick()
 {
+    case "$VERSION" in
+        "8.3")
+            echo "Skipping imagick enable, unsupported php version"
+            return 0
+            ;;
+    esac
+
     _imagick_deps_runtime
     if ! has_extension imagick; then
         compile_imagick true
@@ -13,6 +20,13 @@ function install_imagick()
 function compile_imagick()
 {
     local KEEP_DEPS="${1:-}"
+
+    case "$VERSION" in
+        "8.3")
+            echo "Skipping imagick enable, unsupported php version"
+            return 0
+            ;;
+    esac
 
     _imagick_deps_build
     _imagick_deps_runtime

--- a/installer/base/extensions/mcrypt.sh
+++ b/installer/base/extensions/mcrypt.sh
@@ -23,7 +23,7 @@ function compile_mcrypt()
         7.1)
             docker-php-ext-install mcrypt
             ;;
-        7.*|8.*)
+        7.*|8.[012])
             printf "\n" | pecl install mcrypt
             ;;
         *)

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -27,6 +27,12 @@ for extension in extensions/*; do
         continue
     fi
 
+    # Some extensions not yet ready for PHP 8.3
+    if  [[ "$extension_name" = 'imagick' ]] && version_compare "$PHP_VERSION" ge 8.3; then
+        echo ' skipped'
+        continue
+    fi
+
     # NewRelic PHP agent is currently not supporting other architectures than x86_64 / amd64
     if  [ "$extension_name" = 'newrelic' ] && [ "$(uname -m)" != x86_64 ]; then
         echo ' skipped'

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -28,7 +28,7 @@ for extension in extensions/*; do
     fi
 
     # Some extensions not yet ready for PHP 8.3
-    if  [[ "$extension_name" = 'imagick' ]] && version_compare "$PHP_VERSION" ge 8.3; then
+    if  [[ "$extension_name" = 'imagick' || "$extension_name" = 'mcrypt' ]] && version_compare "$PHP_VERSION" ge 8.3; then
         echo ' skipped'
         continue
     fi


### PR DESCRIPTION
a major change for 8.3 docker tags onwards:
* nodejs no longer will be set up with a default version, however nvm will remain to allow installation
* mcrypt no longer will be enabled by default, as it is long past EOL, and frameworks must have moved away from it by now

extensions not yet supported:
* imagick - bug fix `https://github.com/Imagick/imagick/pull/641` needed
* mcrypt - needs a release allowing 8.3.0 stable