### PR TITLE
Upgrade protobuf and ssh2 to stable, and switch to compose v2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                                 }
                                 steps {
                                     sh 'echo "$DOCKER_REGISTRY_CREDS_PSW" | docker login --username "$DOCKER_REGISTRY_CREDS_USR" --password-stdin docker.io'
-                                    sh 'docker-compose config --services | grep -E "${BUILD}" | xargs docker-compose push'
+                                    sh 'docker compose config --services | grep -E "${BUILD}" | xargs docker compose push'
                                 }
                                 post {
                                     always {
@@ -58,7 +58,7 @@ pipeline {
                         }
                         post {
                             always {
-                                sh 'docker-compose down -v --rmi local'
+                                sh 'docker compose down -v --rmi local'
                                 cleanWs()
                             }
                         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,8 +162,6 @@ services:
         NODE_VERSION: 10
         REDIS_VERSION: 5.0
         BASEOS: stretch
-    depends_on:
-      - php56-fpm-stretch-base
 
   php70-fpm-stretch-console:
     image: my127/php:7.0-fpm-stretch-console${TAG_SUFFIX:-}
@@ -175,8 +173,6 @@ services:
         NODE_VERSION: 10
         REDIS_VERSION: 5.0
         BASEOS: stretch
-    depends_on:
-      - php70-fpm-stretch-base
 
   php71-fpm-stretch-console:
     image: my127/php:7.1-fpm-stretch-console${TAG_SUFFIX:-}
@@ -188,8 +184,6 @@ services:
         NODE_VERSION: 10
         REDIS_VERSION: 5.0
         BASEOS: stretch
-    depends_on:
-      - php71-fpm-stretch-base
 
   php72-fpm-stretch-console:
     image: my127/php:7.2-fpm-stretch-console${TAG_SUFFIX:-}
@@ -201,8 +195,6 @@ services:
         NODE_VERSION: 10
         REDIS_VERSION: 5.0
         BASEOS: stretch
-    depends_on:
-      - php72-fpm-stretch-base
 
   php73-fpm-stretch-console:
     image: my127/php:7.3-fpm-stretch-console${TAG_SUFFIX:-}
@@ -214,8 +206,6 @@ services:
         NODE_VERSION: 10
         REDIS_VERSION: 5.0
         BASEOS: stretch
-    depends_on:
-      - php73-fpm-stretch-base
 
   php73-fpm-buster-console:
     image: my127/php:7.3-fpm-buster-console${TAG_SUFFIX:-}
@@ -226,8 +216,6 @@ services:
         VERSION: 7.3
         NODE_VERSION: 10
         BASEOS: buster
-    depends_on:
-      - php73-fpm-buster-base
 
   php74-fpm-buster-console:
     image: my127/php:7.4-fpm-buster-console${TAG_SUFFIX:-}
@@ -238,8 +226,6 @@ services:
         VERSION: 7.4
         NODE_VERSION: 10
         BASEOS: buster
-    depends_on:
-      - php74-fpm-buster-base
 
   php74-fpm-bullseye-console:
     image: my127/php:7.4-fpm-bullseye-console${TAG_SUFFIX:-}
@@ -250,8 +236,6 @@ services:
         VERSION: 7.4
         NODE_VERSION: 10
         BASEOS: bullseye
-    depends_on:
-      - php74-fpm-bullseye-base
 
   php80-fpm-buster-console:
     image: my127/php:8.0-fpm-buster-console${TAG_SUFFIX:-}
@@ -262,8 +246,6 @@ services:
         VERSION: 8.0
         NODE_VERSION: 10
         BASEOS: buster
-    depends_on:
-      - php80-fpm-buster-base
 
   php80-fpm-bullseye-console:
     image: my127/php:8.0-fpm-bullseye-console${TAG_SUFFIX:-}
@@ -274,8 +256,6 @@ services:
         VERSION: 8.0
         NODE_VERSION: 10
         BASEOS: bullseye
-    depends_on:
-      - php80-fpm-bullseye-base
 
   php81-fpm-bullseye-console:
     image: my127/php:8.1-fpm-bullseye-console${TAG_SUFFIX:-}
@@ -286,8 +266,6 @@ services:
         VERSION: 8.1
         NODE_VERSION: 10
         BASEOS: bullseye
-    depends_on:
-      - php81-fpm-bullseye-base
 
   php81-fpm-bookworm-console:
     image: my127/php:8.1-fpm-bookworm-console${TAG_SUFFIX:-}
@@ -298,8 +276,6 @@ services:
         VERSION: 8.1
         NODE_VERSION: 10
         BASEOS: bookworm
-    depends_on:
-      - php81-fpm-bookworm-base
 
   php82-fpm-bullseye-console:
     image: my127/php:8.2-fpm-bullseye-console${TAG_SUFFIX:-}
@@ -310,8 +286,6 @@ services:
         VERSION: 8.2
         NODE_VERSION: 10
         BASEOS: bullseye
-    depends_on:
-      - php82-fpm-bullseye-base
 
   php82-fpm-bookworm-console:
     image: my127/php:8.2-fpm-bookworm-console${TAG_SUFFIX:-}
@@ -322,5 +296,3 @@ services:
         VERSION: 8.2
         NODE_VERSION: 10
         BASEOS: bookworm
-    depends_on:
-      - php82-fpm-bookworm-base

--- a/installer/base/extensions/mongodb.sh
+++ b/installer/base/extensions/mongodb.sh
@@ -22,6 +22,9 @@ function compile_mongodb()
         "7.1")
             pecl install mongodb-1.11.1
             ;;
+        7.2|7.3)
+            pecl install mongodb-1.16.2
+            ;;
         *)
             pecl install mongodb
     esac

--- a/installer/base/extensions/protobuf.sh
+++ b/installer/base/extensions/protobuf.sh
@@ -16,7 +16,7 @@ function compile_protobuf()
             printf "\n" | pecl install protobuf-3.12.4
             ;;
         "7.*")
-            printf "\n" | pecl install protobuf-3.20.1
+            printf "\n" | pecl install protobuf-3.20.1RC1
             ;;
         *)
             printf "\n" | pecl install protobuf

--- a/installer/base/extensions/protobuf.sh
+++ b/installer/base/extensions/protobuf.sh
@@ -6,26 +6,19 @@ function install_protobuf()
         compile_protobuf
     fi
 
-    case "$VERSION" in
-        "8.0")
-            echo "Skipping protobuf enable, unsupported php version"
-            return 0
-            ;;
-    esac
-
     docker-php-ext-enable protobuf
 }
 
 function compile_protobuf()
 {
     case "$VERSION" in
-        "8.0")
-            echo "Skipping protobuf install, unsupported php version"
-            ;;
         "5.6")
             printf "\n" | pecl install protobuf-3.12.4
             ;;
+        "7.*")
+            printf "\n" | pecl install protobuf-3.20.1
+            ;;
         *)
-            printf "\n" | pecl install protobuf-3.20.1RC1
+            printf "\n" | pecl install protobuf
     esac
 }

--- a/installer/base/extensions/protobuf.sh
+++ b/installer/base/extensions/protobuf.sh
@@ -15,8 +15,8 @@ function compile_protobuf()
         "5.6")
             printf "\n" | pecl install protobuf-3.12.4
             ;;
-        "7.*")
-            printf "\n" | pecl install protobuf-3.20.1RC1
+        7.*)
+            printf "\n" | pecl install protobuf-3.20.1
             ;;
         *)
             printf "\n" | pecl install protobuf

--- a/installer/base/extensions/ssh2.sh
+++ b/installer/base/extensions/ssh2.sh
@@ -6,13 +6,6 @@ function install_ssh2()
         compile_ssh2
     fi
 
-    case "$VERSION" in
-        "8.0")
-            echo "Skipping ssh2 enable, unsupported php version"
-            return 0
-            ;;
-    esac
-
     docker-php-ext-enable ssh2
 }
 
@@ -20,15 +13,11 @@ function compile_ssh2()
 {
     _ssh2_deps_build
     case "$VERSION" in
-        "8.0")
-            echo "Skipping ssh2 installation due to unsupported php version"
-            ;;
         "5.6")
             printf "\n" | pecl install ssh2-0.13
             ;;
         *)
-            # beta release, so need to specify version number
-            printf "\n" | pecl install ssh2-1.2
+            printf "\n" | pecl install ssh2
     esac
 
     _ssh2_clean

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -27,12 +27,6 @@ for extension in extensions/*; do
         continue
     fi
 
-    # Some extensions only available for PHP <8.1
-    if  [[ "$extension_name" = 'mcrypt' ]] && version_compare "$PHP_VERSION" ge 8.1; then
-        echo ' skipped'
-        continue
-    fi
-
     # NewRelic PHP agent is currently not supporting other architectures than x86_64 / amd64
     if  [ "$extension_name" = 'newrelic' ] && [ "$(uname -m)" != x86_64 ]; then
         echo ' skipped'

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -26,11 +26,6 @@ for extension in extensions/*; do
         echo ' skipped'
         continue
     fi
-    # Some extensions only available for PHP <8.0
-    if  [[ "$extension_name" = 'protobuf' || "$extension_name" = 'ssh2' ]] && version_compare "$PHP_VERSION" ge 8.0; then
-        echo ' skipped'
-        continue
-    fi
 
     # Some extensions only available for PHP <8.1
     if  [[ "$extension_name" = 'mcrypt' ]] && version_compare "$PHP_VERSION" ge 8.1; then

--- a/test.sh
+++ b/test.sh
@@ -4,13 +4,13 @@ set -e -o pipefail
 
 BUILD="${BUILD:-}"
 
-for SERVICE in $(docker-compose config --services | grep -E "${BUILD}" | grep base); do
+for SERVICE in $(docker compose config --services | grep -E "${BUILD}" | grep base); do
   echo
   echo "Testing service ${service}"
-  docker-compose run --rm -v "$(pwd)/test.extensions.sh:/app/test.extensions.sh" "${SERVICE}" /app/test.extensions.sh
+  docker compose run --rm -v "$(pwd)/test.extensions.sh:/app/test.extensions.sh" "${SERVICE}" /app/test.extensions.sh
 done
 
-for SERVICE in $(docker-compose config --services | grep -E "${BUILD}" | grep console); do
+for SERVICE in $(docker compose config --services | grep -E "${BUILD}" | grep console); do
   # shellcheck disable=SC2016
-  docker-compose run --rm "${SERVICE}" bash -e -c 'php -m; php -v'
+  docker compose run --rm "${SERVICE}" bash -e -c 'php -m; php -v'
 done


### PR DESCRIPTION
* Upgrade protobuf and ssh2 to stable and include in php 8.0 as well
* Change compose binary to v2 docker plugin
* Add testing 8.* for mcrypt
* Pin mongodb back in 7.2/7.3 since new version drops support for php < 7.4