### PR TITLE
Add WebP and XPM support to GD

### DIFF
--- a/installer/base/extensions/gd.sh
+++ b/installer/base/extensions/gd.sh
@@ -39,11 +39,16 @@ function compile_gd()
 
 function _gd_deps_runtime()
 {
+    local WEBP_PACKAGE=libwebp7
+    if [ "$BASEOS" = buster ] || [ "$BASEOS" = bullseye ]; then
+      WEBP_PACKAGE=libwebp6
+    fi
+
     install \
       libfreetype6 \
       libjpeg62-turbo \
       libpng16-16 \
-      libwebp6 \
+      "$WEBP_PACKAGE" \
       libxpm4 \
       zlib1g
 }
@@ -66,5 +71,6 @@ function _gd_clean()
       libjpeg62-turbo-dev \
       libpng-dev \
       libwebp-dev \
-      libxpm-dev
+      libxpm-dev \
+      zlib1g-dev
 }

--- a/installer/base/extensions/gd.sh
+++ b/installer/base/extensions/gd.sh
@@ -19,13 +19,17 @@ function compile_gd()
                   --with-gd \
                   --with-freetype-dir=/usr/include/ \
                   --with-png-dir=/usr/include/ \
-                  --with-jpeg-dir=/usr/include/
+                  --with-jpeg-dir=/usr/include/ \
+                  --with-webp-dir=/usr/include/ \
+                  --with-xpm-dir=/usr/include/
                 ;;
             *)
                 docker-php-ext-configure gd \
                   --enable-gd \
                   --with-freetype \
-                  --with-jpeg
+                  --with-jpeg \
+                  --with-webp \
+                  --with-xpm
     esac
 
     docker-php-ext-install gd
@@ -39,6 +43,8 @@ function _gd_deps_runtime()
       libfreetype6 \
       libjpeg62-turbo \
       libpng16-16 \
+      libwebp6 \
+      libxpm4 \
       zlib1g
 }
 
@@ -48,6 +54,8 @@ function _gd_deps_build()
       libfreetype6-dev \
       libjpeg62-turbo-dev \
       libpng-dev \
+      libwebp-dev \
+      libxpm-dev \
       zlib1g-dev
 }
 
@@ -56,5 +64,7 @@ function _gd_clean()
     remove \
       libfreetype6-dev \
       libjpeg62-turbo-dev \
-      libpng-dev
+      libpng-dev \
+      libwebp-dev \
+      libxpm-dev
 }


### PR DESCRIPTION
Fixes the warning message "The GD or ImageMagick library must be compiled with WebP support on your server." in drupal when imagemagick is not enabled.