### PR TITLE
Pre-compile mcrypt on PHP 8.3

### DIFF
--- a/installer/base/extensions/mcrypt.sh
+++ b/installer/base/extensions/mcrypt.sh
@@ -15,14 +15,7 @@ function compile_mcrypt()
 {
     _mcrypt_deps_build
 
-    case "$VERSION" in
-        7.*|8.[012])
-            printf "\n" | pecl install mcrypt
-            ;;
-        *)
-            echo "mcrypt is not supported by PHP ${VERSION}" >&2
-            ;;
-    esac
+    printf "\n" | pecl install mcrypt
 
     _mcrypt_clean
 }

--- a/test.extensions.sh
+++ b/test.extensions.sh
@@ -16,12 +16,6 @@ for extension in extensions/*.sh; do
     extension_name="${extension%.sh}"
     extension_name="${extension_name#extensions/}"
 
-    # Some extensions not yet ready for PHP 8.3
-    if  [[ "$extension_name" = 'mcrypt' ]] && version_compare "$PHP_VERSION" ge 8.3; then
-        echo ' skipped'
-        continue
-    fi
-
     # NewRelic PHP agent is currently not supporting other architectures than x86_64 / amd64
     if  [ "$extension_name" = 'newrelic' ] && [ "$(uname -m)" != x86_64 ]; then
         echo ' skipped'


### PR DESCRIPTION
It will still be disabled by default as not supposed to be used anymore