### PR TITLE
Cleanup temp files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,9 @@ RUN <<EOF
     set +o nounset
     . /home/build/.nvm/nvm.sh
     nvm install "${NODE_VERSION}"
+    nvm cache clean
     npm install -g yarn
+    npm cache clear --force
     set -o nounset
   fi
 
@@ -161,6 +163,7 @@ RUN <<EOF
   # enables parallel downloading of composer depedencies and massively speeds up the
   # time it takes to run composer install.
   composer global require hirak/prestissimo
+  composer global clear-cache
 EOF
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,7 @@ RUN <<EOF
     set +o nounset
     . /home/build/.nvm/nvm.sh
     nvm install "${NODE_VERSION}"
-    nvm cache clean
+    nvm cache clear
     npm install -g yarn
     npm cache clear --force
     set -o nounset

--- a/installer/base/lib/functions.sh
+++ b/installer/base/lib/functions.sh
@@ -86,6 +86,10 @@ function clean()
     apt-get clean
 
     rm -rf /var/lib/apt/lists/*
+
+    pear clear-cache
+    rm -rf /tmp/pear/
+    rm -f /tmp/package.xml
 }
 
 function install()

--- a/installer/base/lib/functions.sh
+++ b/installer/base/lib/functions.sh
@@ -87,7 +87,6 @@ function clean()
 
     rm -rf /var/lib/apt/lists/*
 
-    pear clear-cache
     rm -rf /tmp/pear/
     rm -f /tmp/package.xml
 }


### PR DESCRIPTION
* `/home/build/.composer/cache/` - 21MB
* `/home/build/.npm/_cacache/` - 1.4MB
* `/home/build/.nvm/.cache/` -  13MB
* `/tmp/package.xml` - 45kB
* `/tmp/pear/cache/` - 97kB
* `/tmp/pear/download/` - 9.8MB