### PR TITLE
Upgrade NVM. Pre-install composer v2 for PHP 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ RUN <<EOF
   # ----------------------------------
   # enables parallel downloading of composer depedencies and massively speeds up the
   # time it takes to run composer install.
-  if [ "${COMPOSER_VERSION:0:2}" = "1." ]; then
+  if dpkg --compare-versions "$COMPOSER_VERSION" lt 2.0; then
     composer global require hirak/prestissimo
   fi
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ FROM base as console
 STOPSIGNAL SIGTERM
 
 ARG BASEOS
+ARG COMPOSER_VERSION
 ARG NODE_VERSION
 ENV IMAGE_TYPE=console
 RUN <<EOF
@@ -121,16 +122,16 @@ RUN <<EOF
 
   # Tool: composer
   # --------------
-  curl --fail --silent --show-error --location --retry 3 --output /tmp/composer-installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/650bee119e1f3b87be1b787fe69a826f73dbdfb9/web/installer
+  curl --fail --silent --show-error --location --retry 3 --output /tmp/composer-installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/993f9fec74930f32f7015e71543243bf6d9b9e93/web/installer
   php -r '
-    $signature = "906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8";
+    $signature = "dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6";
     $hash = hash("sha384", file_get_contents("/tmp/composer-installer.php"));
     if (!hash_equals($signature, $hash)) {
         unlink("/tmp/composer-installer.php");
         echo "Integrity check failed, installer is either corrupt or worse." . PHP_EOL;
         exit(1);
     }'
-  php /tmp/composer-installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=1.10.26
+  php /tmp/composer-installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version="$COMPOSER_VERSION"
   rm /tmp/composer-installer.php
 EOF
 
@@ -146,7 +147,9 @@ RUN <<EOF
   # -------------------------------------
   cd /home/build
   mkdir .nvm
-  curl --fail --silent --show-error --location --output - https://raw.githubusercontent.com/creationix/nvm/v0.39.0/install.sh | bash
+  curl --fail --silent --show-error --location --output /tmp/nvm.sh https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh
+  bash /tmp/nvm.sh
+  rm /tmp/nvm.sh
 
   if [ "${NODE_VERSION:-}" ]; then
     set +o nounset
@@ -156,11 +159,13 @@ RUN <<EOF
     set -o nounset
   fi
 
-  # Tool: composer > hirak/prestissimo
+  # Tool: composer v1 > hirak/prestissimo
   # ----------------------------------
   # enables parallel downloading of composer depedencies and massively speeds up the
   # time it takes to run composer install.
-  composer global require hirak/prestissimo
+  if [ "${COMPOSER_VERSION:0:2}" = "1." ]; then
+    composer global require hirak/prestissimo
+  fi
 EOF
 
 USER root

--- a/README.md
+++ b/README.md
@@ -12,21 +12,26 @@ A starting point with some common extensions for running various frameworks and 
 * php-xdebug
 * php-xsl
 * php-zip
+
 ## Console
+
 Used in development for building and interacting with the application with a familiar set of tools, can also be used as part of a multi-stage build docker image.
+
 ### Packages
+
 * build-tools (autoconf, automake, g++, gcc, make, nasm)
-* composer (1.8.4)
+* composer (1.10.27 or 2.7.2)
 * curl
 * gettext-base
 * git
 * iproute
 * mysql (client)
 * nano
-* node (lts/dubnium)
+* nvm
+* node (lts/dubnium aka v10, or none for PHP 8.3+)
 * npm
 * patch
 * rsync
 * wget
-* yarn
+* yarn (if node is installed)
 * zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       target: base
       args:
         VERSION: 7.3
-        NODE_VERSION: 10
         BASEOS: buster
 
   php74-fpm-buster-base:
@@ -20,7 +19,6 @@ services:
       target: base
       args:
         VERSION: 7.4
-        NODE_VERSION: 10
         BASEOS: buster
 
   php74-fpm-bullseye-base:
@@ -30,7 +28,6 @@ services:
       target: base
       args:
         VERSION: 7.4
-        NODE_VERSION: 10
         BASEOS: bullseye
 
   php80-fpm-buster-base:
@@ -40,7 +37,6 @@ services:
       target: base
       args:
         VERSION: 8.0
-        NODE_VERSION: 10
         BASEOS: buster
 
   php80-fpm-bullseye-base:
@@ -50,7 +46,6 @@ services:
       target: base
       args:
         VERSION: 8.0
-        NODE_VERSION: 10
         BASEOS: bullseye
 
   php81-fpm-bullseye-base:
@@ -60,7 +55,6 @@ services:
       target: base
       args:
         VERSION: 8.1
-        NODE_VERSION: 10
         BASEOS: bullseye
 
   php81-fpm-bookworm-base:
@@ -70,7 +64,6 @@ services:
       target: base
       args:
         VERSION: 8.1
-        NODE_VERSION: 10
         BASEOS: bookworm
 
   php82-fpm-bullseye-base:
@@ -80,7 +73,6 @@ services:
       target: base
       args:
         VERSION: 8.2
-        NODE_VERSION: 10
         BASEOS: bullseye
 
   php82-fpm-bookworm-base:
@@ -90,7 +82,6 @@ services:
       target: base
       args:
         VERSION: 8.2
-        NODE_VERSION: 10
         BASEOS: bookworm
 
   php83-fpm-bookworm-base:
@@ -112,6 +103,7 @@ services:
       target: console
       args:
         VERSION: 7.3
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: buster
 
@@ -122,6 +114,7 @@ services:
       target: console
       args:
         VERSION: 7.4
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: buster
 
@@ -132,6 +125,7 @@ services:
       target: console
       args:
         VERSION: 7.4
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: bullseye
 
@@ -142,6 +136,7 @@ services:
       target: console
       args:
         VERSION: 8.0
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: buster
 
@@ -152,6 +147,7 @@ services:
       target: console
       args:
         VERSION: 8.0
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: bullseye
 
@@ -162,6 +158,7 @@ services:
       target: console
       args:
         VERSION: 8.1
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: bullseye
 
@@ -172,6 +169,7 @@ services:
       target: console
       args:
         VERSION: 8.1
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: bookworm
 
@@ -182,6 +180,7 @@ services:
       target: console
       args:
         VERSION: 8.2
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: bullseye
 
@@ -192,6 +191,7 @@ services:
       target: console
       args:
         VERSION: 8.2
+        COMPOSER_VERSION: 1.10.27
         NODE_VERSION: 10
         BASEOS: bookworm
 
@@ -202,5 +202,6 @@ services:
       target: console
       args:
         VERSION: 8.3
+        COMPOSER_VERSION: 2.7.2
         REDIS_VERSION: 7.2
         BASEOS: bookworm


### PR DESCRIPTION
* NODE_VERSION not used in the base image target, so no need to supply the build arg
* NVM now owned by an organisation, install latest bugfix version.
* Upgrade composer installer to latest.
* Replace composer v1 with v2 for PHP 8.3 images, hopefully no-one wanting this version combo.