### PR TITLE
Pin protobuf to older version for PHP 8.0

### DIFF
--- a/installer/base/extensions/protobuf.sh
+++ b/installer/base/extensions/protobuf.sh
@@ -13,7 +13,10 @@ function compile_protobuf()
 {
     case "$VERSION" in
         7.*)
-            printf "\n" | pecl install protobuf-3.20.1
+            printf "\n" | pecl install protobuf-3.20.3
+            ;;
+        8.0)
+            printf "\n" | pecl install protobuf-3.25.3
             ;;
         *)
             printf "\n" | pecl install protobuf


### PR DESCRIPTION
[4.26.0](https://pecl.php.net/package/protobuf/4.26.0) released yesterday only supports PHP 8.1