### PR TITLE
bug: workaround composer global remove issue on v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,10 @@ RUN <<EOF
   if dpkg --compare-versions "$COMPOSER_VERSION" lt 2.0; then
     composer global require hirak/prestissimo
     composer global clear-cache
+  else
+    # workaround to make 'composer global remove ...' not fail when it can't fine this file
+    mkdir ~/.composer
+    echo '{}' > ~/.composer/composer.json
   fi
 EOF
 


### PR DESCRIPTION
PHP harness still attempts removal of hrak/presstissimo when composer.version 2 selected

removal fails due to ~/.composer/composer.json not existing, but succeeds with warning when the package isn't installed, when it can read the file.