### PR TITLE
feat: add PHP 8.3/8.4 Debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,9 +122,9 @@ RUN <<EOF
 
   # Tool: composer
   # --------------
-  curl --fail --silent --show-error --location --retry 3 --output /tmp/composer-installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/993f9fec74930f32f7015e71543243bf6d9b9e93/web/installer
+  curl --fail --silent --show-error --location --retry 3 --output /tmp/composer-installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/385045ba212b5b73c1710fe6228ef024007d0a73/web/installer
   php -r '
-    $signature = "dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6";
+    $signature = "c8b085408188070d5f52bcfe4ecfbee5f727afa458b2573b8eaaf77b3419b0bf2768dc67c86944da1544f06fa544fd47";
     $hash = hash("sha384", file_get_contents("/tmp/composer-installer.php"));
     if (!hash_equals($signature, $hash)) {
         unlink("/tmp/composer-installer.php");
@@ -161,18 +161,11 @@ RUN <<EOF
     set -o nounset
   fi
 
-  # Tool: composer v1 > hirak/prestissimo
+  # Tool: composer
   # ----------------------------------
-  # enables parallel downloading of composer depedencies and massively speeds up the
-  # time it takes to run composer install.
-  if dpkg --compare-versions "$COMPOSER_VERSION" lt 2.0; then
-    composer global require hirak/prestissimo
-    composer global clear-cache
-  else
-    # workaround to make 'composer global remove ...' not fail when it can't fine this file
-    mkdir ~/.composer
-    echo '{}' > ~/.composer/composer.json
-  fi
+  # workaround to make 'composer global remove ...' not fail when it can't fine this file
+  mkdir ~/.composer
+  echo '{}' > ~/.composer/composer.json
 EOF
 
 USER root

--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
 # PHP Images
+
+## Contents
+
+- [Base](#base)
+- [Console](#console)
+- [Supported Versions](#supported-versions)
+- [Build and Test](#build-and-test)
+
 ## Base
+
 A starting point with some common extensions for running various frameworks and applications.
+
+<!-- markdownlint-disable MD024 -->
+
 ### Packages
-* php-bcmath
-* php-gd
-* php-intl
-* php-mcrypt
-* php-opcache
-* php-pdo (mysql)
-* php-soap
-* php-xdebug
-* php-xsl
-* php-zip
+
+- php-bcmath
+- php-gd
+- php-intl
+- php-mcrypt
+- php-opcache
+- php-pdo (mysql)
+- php-soap
+- php-xdebug
+- php-xsl
+- php-zip
 
 ## Console
 
@@ -19,19 +32,66 @@ Used in development for building and interacting with the application with a fam
 
 ### Packages
 
-* build-tools (autoconf, automake, g++, gcc, make, nasm)
-* composer (1.10.27 or 2.7.2)
-* curl
-* gettext-base
-* git
-* iproute
-* mysql (client)
-* nano
-* nvm
-* node (lts/dubnium aka v10, or none for PHP 8.3+)
-* npm
-* patch
-* rsync
-* wget
-* yarn (if node is installed)
-* zip
+- build-tools (autoconf, automake, g++, gcc, make, nasm)
+- composer (1.10.27 or 2.7.2)
+- curl
+- gettext-base
+- git
+- iproute
+- mysql (client)
+- nano
+- nvm
+- node (lts/dubnium aka v10, or none for PHP 8.3+)
+- npm
+- patch
+- redis-cli
+- rsync
+- wget
+- yarn (if node is installed)
+- zip
+
+## Supported Versions
+
+| PHP version | Bookworm | Trixie |
+| --- | --- | --- |
+| `8.3` | Base + Console | Base + Console |
+| `8.4` | Base + Console | Base + Console |
+
+## Build and Test
+
+Build and test all Trixie images:
+
+```bash
+BUILD=trixie ./build.sh
+BUILD=trixie ./test.sh
+docker image rm \
+  my127/php:8.3-fpm-trixie \
+  my127/php:8.3-fpm-trixie-console \
+  my127/php:8.4-fpm-trixie \
+  my127/php:8.4-fpm-trixie-console
+```
+
+Build and test all PHP 8.4 images:
+
+```bash
+BUILD=php84 ./build.sh
+BUILD=php84 ./test.sh
+docker image rm \
+  my127/php:8.4-fpm-bookworm \
+  my127/php:8.4-fpm-bookworm-console \
+  my127/php:8.4-fpm-trixie \
+  my127/php:8.4-fpm-trixie-console
+```
+
+Build and test a single image:
+
+```bash
+BUILD=php84-fpm-trixie-console ./build.sh
+BUILD=php84-fpm-trixie-console ./test.sh
+```
+
+Remove locally built images when finished:
+
+```bash
+docker image rm my127/php:8.4-fpm-trixie-console
+```

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ Used in development for building and interacting with the application with a fam
 
 ## Supported Versions
 
-| PHP version | Bookworm | Trixie |
-| --- | --- | --- |
-| `8.3` | Base + Console | Base + Console |
-| `8.4` | Base + Console | Base + Console |
+| PHP version | Bullseye | Bookworm | Trixie |
+| ----------- | -------- | -------- | ------ |
+| `8.2`       | x        | x        |
+| `8.3`       |          | x        | x      |
+| `8.4`       |          | x        | x      |
 
 ## Build and Test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       target: console
       args:
         VERSION: "8.2"
-        COMPOSER_VERSION: "2.8.12"
+        COMPOSER_VERSION: "2.10.1"
         NODE_VERSION: "10"
         REDIS_VERSION: "6.2"
         BASEOS: bullseye
@@ -74,7 +74,7 @@ services:
       target: console
       args:
         VERSION: "8.2"
-        COMPOSER_VERSION: "2.8.12"
+        COMPOSER_VERSION: "2.10.1"
         NODE_VERSION: "10"
         REDIS_VERSION: "6.2"
         BASEOS: bookworm
@@ -86,8 +86,8 @@ services:
       target: console
       args:
         VERSION: "8.3"
-        COMPOSER_VERSION: "2.8.12"
-        REDIS_VERSION: "7.2"
+        COMPOSER_VERSION: "2.10.1"
+        REDIS_VERSION: "7.4"
         BASEOS: bookworm
 
   php83-fpm-trixie-console:
@@ -97,8 +97,8 @@ services:
       target: console
       args:
         VERSION: "8.3"
-        COMPOSER_VERSION: "2.8.12"
-        REDIS_VERSION: "8.2"
+        COMPOSER_VERSION: "2.10.1"
+        REDIS_VERSION: "8.8"
         BASEOS: trixie
 
   php84-fpm-bookworm-console:
@@ -108,7 +108,7 @@ services:
       target: console
       args:
         VERSION: "8.4"
-        COMPOSER_VERSION: "2.8.12"
+        COMPOSER_VERSION: "2.10.1"
         REDIS_VERSION: "7.4"
         BASEOS: bookworm
 
@@ -119,6 +119,6 @@ services:
       target: console
       args:
         VERSION: "8.4"
-        COMPOSER_VERSION: "2.8.12"
-        REDIS_VERSION: "8.2"
+        COMPOSER_VERSION: "2.10.1"
+        REDIS_VERSION: "8.8"
         BASEOS: trixie

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,15 @@ services:
         VERSION: "8.3"
         BASEOS: bookworm
 
+  php83-fpm-trixie-base:
+    image: my127/php:8.3-fpm-trixie${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: base
+      args:
+        VERSION: "8.3"
+        BASEOS: trixie
+
   php84-fpm-bookworm-base:
     image: my127/php:8.4-fpm-bookworm${TAG_SUFFIX:-}
     build:
@@ -35,6 +44,15 @@ services:
       args:
         VERSION: "8.4"
         BASEOS: bookworm
+
+  php84-fpm-trixie-base:
+    image: my127/php:8.4-fpm-trixie${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: base
+      args:
+        VERSION: "8.4"
+        BASEOS: trixie
 
   # Console Images
   php82-fpm-bullseye-console:
@@ -72,6 +90,17 @@ services:
         REDIS_VERSION: "7.2"
         BASEOS: bookworm
 
+  php83-fpm-trixie-console:
+    image: my127/php:8.3-fpm-trixie-console${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: console
+      args:
+        VERSION: "8.3"
+        COMPOSER_VERSION: "2.8.12"
+        REDIS_VERSION: "8.2"
+        BASEOS: trixie
+
   php84-fpm-bookworm-console:
     image: my127/php:8.4-fpm-bookworm-console${TAG_SUFFIX:-}
     build:
@@ -82,3 +111,14 @@ services:
         COMPOSER_VERSION: "2.8.12"
         REDIS_VERSION: "7.4"
         BASEOS: bookworm
+
+  php84-fpm-trixie-console:
+    image: my127/php:8.4-fpm-trixie-console${TAG_SUFFIX:-}
+    build:
+      context: ./
+      target: console
+      args:
+        VERSION: "8.4"
+        COMPOSER_VERSION: "2.8.12"
+        REDIS_VERSION: "8.2"
+        BASEOS: trixie

--- a/installer/base/extensions/tideways.sh
+++ b/installer/base/extensions/tideways.sh
@@ -27,10 +27,6 @@ function _tideways_deps_runtime()
 
 function _tideways_deps_build()
 {
-    install \
-      apt-transport-https \
-      gnupg2
-
     curl --fail --silent --show-error --location --output /usr/share/keyrings/tideways.asc 'https://packages.tideways.com/key.gpg'
     echo 'deb [signed-by=/usr/share/keyrings/tideways.asc] https://packages.tideways.com/apt-packages-main any-version main' > /etc/apt/sources.list.d/tideways.list
     apt-get update -qq

--- a/installer/base/extensions/tideways.sh
+++ b/installer/base/extensions/tideways.sh
@@ -31,7 +31,7 @@ function _tideways_deps_build()
       apt-transport-https \
       gnupg2
 
-    echo 'deb https://packages.tideways.com/apt-packages-main any-version main' > /etc/apt/sources.list.d/tideways.list
-    curl --fail --silent --show-error --location 'https://packages.tideways.com/key.gpg' | apt-key add -
+    curl --fail --silent --show-error --location --output /usr/share/keyrings/tideways.asc 'https://packages.tideways.com/key.gpg'
+    echo 'deb [signed-by=/usr/share/keyrings/tideways.asc] https://packages.tideways.com/apt-packages-main any-version main' > /etc/apt/sources.list.d/tideways.list
     apt-get update -qq
 }

--- a/installer/base/extensions/zip.sh
+++ b/installer/base/extensions/zip.sh
@@ -22,6 +22,10 @@ function compile_zip()
 
 function _zip_deps_runtime()
 {
+    if [ "${BASEOS}" = "trixie" ]; then
+        install libzip5
+        return
+    fi
     install libzip4
 }
 

--- a/installer/trixie/extensions/event.sh
+++ b/installer/trixie/extensions/event.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+function install_event()
+{
+    if ! has_extension event; then
+        compile_event
+    fi
+
+    _event_deps_runtime
+
+    docker-php-ext-enable --ini-name zz-docker-php-ext-event.ini event
+}
+
+function compile_event()
+{
+    _event_deps_build
+
+    if ! printf "\n" | pecl install event; then
+        return 1
+    fi
+
+    _event_clean
+}
+
+function _event_deps_runtime()
+{
+    enable \
+      sockets
+
+    install \
+      libevent-2.1-7t64 \
+      libevent-extra-2.1-7t64 \
+      libevent-openssl-2.1-7t64
+}
+
+function _event_deps_build()
+{
+    enable \
+      sockets
+
+    install \
+      libevent-dev \
+      libssl-dev
+}
+
+function _event_clean()
+{
+    remove \
+      libevent-dev \
+      libssl-dev
+
+    if [ -f "/usr/local/etc/php/conf.d/docker-php-ext-sockets.ini" ]; then
+        rm "/usr/local/etc/php/conf.d/docker-php-ext-sockets.ini"
+    fi
+}

--- a/installer/trixie/extensions/intl.sh
+++ b/installer/trixie/extensions/intl.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+function install_intl()
+{
+    _intl_deps_runtime
+    if ! has_extension intl; then
+        compile_intl
+    fi
+    docker-php-ext-enable intl
+}
+
+function compile_intl()
+{
+    _intl_deps_build
+
+    docker-php-ext-install intl
+
+    _intl_clean
+}
+
+function _intl_deps_runtime()
+{
+    install libicu76
+}
+
+function _intl_deps_build()
+{
+    install icu-devtools libicu-dev
+}
+
+function _intl_clean()
+{
+    remove icu-devtools libicu-dev
+}

--- a/installer/trixie/extensions/memcached.sh
+++ b/installer/trixie/extensions/memcached.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+function install_memcached()
+{
+    _memcached_deps_runtime
+
+    if ! has_extension memcached; then
+        compile_memcached
+    fi
+
+    docker-php-ext-enable memcached
+}
+
+function compile_memcached()
+{
+    _memcached_deps_build
+
+    printf "\n" | pecl install memcached
+
+    _memcached_clean
+}
+
+function _memcached_deps_runtime()
+{
+    install libmemcached11t64 libmemcachedutil2t64
+}
+
+function _memcached_deps_build()
+{
+    install libmemcached-dev libssl-dev zlib1g-dev
+}
+
+function _memcached_clean()
+{
+    remove libmemcached-dev libssl-dev zlib1g-dev
+}


### PR DESCRIPTION
- Added PHP 8.3 and 8.4 Debian Trixie (13) image entries to the build matrix
- Updated Trixie console builds to use `REDIS_VERSION: "8.8"`, updated Composer to `2.10.1`
- Updated Trixie runtime package names for event, intl, memcached, and zip extension dependencies
- Updated Tideways apt setup to per-repo keystore more preferred for trust security.
- Added README contents, supported versions, and build/test examples.